### PR TITLE
Add Prometheus metrics

### DIFF
--- a/fa_search_bot/bot.py
+++ b/fa_search_bot/bot.py
@@ -11,6 +11,7 @@ from telethon import TelegramClient
 from yippi import AsyncYippiClient
 
 from fa_search_bot._version import __VERSION__
+from fa_search_bot.functionalities.functionalities import usage_counter
 from fa_search_bot.functionalities.inline_edit import InlineEditFunctionality, InlineEditButtonPress
 from fa_search_bot.sites.e621_handler import E621Handler
 from fa_search_bot.sites.fa_export_api import FAExportAPI
@@ -157,7 +158,7 @@ class FASearchBot:
             self.e6_handler.site_code: self.e6_handler,
         }
         initialise_metrics_labels(list(handlers.values()))
-        return [
+        functionalities = [
             BeepFunctionality(),
             WelcomeFunctionality(),
             ImageHashRecommendFunctionality(),
@@ -171,3 +172,7 @@ class FASearchBot:
             SupergroupUpgradeFunctionality(self.subscription_watcher),
             UnhandledMessageFunctionality(),
         ]
+        for functionality in functionalities:
+            for label in functionality.usage_labels:
+                usage_counter.labels(function=label)
+        return functionalities

--- a/fa_search_bot/bot.py
+++ b/fa_search_bot/bot.py
@@ -1,7 +1,7 @@
 import asyncio
 import dataclasses
 
-from typing import Dict
+from typing import Dict, Optional
 
 import logging
 import json
@@ -65,13 +65,15 @@ class Config:
     fa_api_url: str
     telegram: TelegramConfig
     e621: E621Config
+    prometheus_port: Optional[int]
 
     @classmethod
     def from_dict(cls, conf: Dict) -> 'Config':
         return cls(
             conf["api_url"],
             TelegramConfig.from_dict(conf),
-            E621Config.from_dict(conf["e621"])
+            E621Config.from_dict(conf["e621"]),
+            conf.get("prometheus_port", 7065)
         )
 
 
@@ -98,7 +100,7 @@ class FASearchBot:
         return self.config.telegram.bot_token
 
     def start(self):
-        start_http_server(7065)
+        start_http_server(self.config.prometheus_port)
         info.info({
             "version": __VERSION__,
         })

--- a/fa_search_bot/bot.py
+++ b/fa_search_bot/bot.py
@@ -24,6 +24,7 @@ from fa_search_bot.functionalities.supergroup_upgrade import SupergroupUpgradeFu
 from fa_search_bot.functionalities.unhandled import UnhandledMessageFunctionality
 from fa_search_bot.functionalities.welcome import WelcomeFunctionality
 from fa_search_bot.sites.fa_handler import FAHandler
+from fa_search_bot.sites.sendable import initialise_metrics_labels
 from fa_search_bot.subscription_watcher import SubscriptionWatcher
 
 logger = logging.getLogger(__name__)
@@ -153,6 +154,7 @@ class FASearchBot:
             fa_handler.site_code: fa_handler,
             self.e6_handler.site_code: self.e6_handler,
         }
+        initialise_metrics_labels(list(handlers.values()))
         return [
             BeepFunctionality(),
             WelcomeFunctionality(),

--- a/fa_search_bot/bot.py
+++ b/fa_search_bot/bot.py
@@ -6,6 +6,7 @@ from typing import Dict
 import logging
 import json
 
+from prometheus_client import start_http_server
 from telethon import TelegramClient
 from yippi import AsyncYippiClient
 
@@ -94,6 +95,7 @@ class FASearchBot:
         return self.config.telegram.bot_token
 
     def start(self):
+        start_http_server(7065)
         self.e6_api.login(self.config.e621.username, self.config.e621.api_key)
         self.client = TelegramClient("fasearchbot", self.config.telegram.api_id, self.config.telegram.api_hash)
         self.client.start(bot_token=self.config.telegram.bot_token)
@@ -133,7 +135,7 @@ class FASearchBot:
         while self.alive:
             logger.info("Main thread alive")
             try:
-                await asyncio.sleep(2)
+                await asyncio.sleep(20)
             except KeyboardInterrupt:
                 logger.info("Received keyboard interrupt")
                 self.alive = False

--- a/fa_search_bot/bot.py
+++ b/fa_search_bot/bot.py
@@ -6,7 +6,7 @@ from typing import Dict
 import logging
 import json
 
-from prometheus_client import start_http_server
+from prometheus_client import start_http_server, Info, Gauge
 from telethon import TelegramClient
 from yippi import AsyncYippiClient
 
@@ -27,6 +27,8 @@ from fa_search_bot.sites.fa_handler import FAHandler
 from fa_search_bot.subscription_watcher import SubscriptionWatcher
 
 logger = logging.getLogger(__name__)
+info = Info("fasearchbot_info", "Information about the FASearchBot instance")
+start_time = Gauge("fasearchbot_startup_unixtime", "Last time FASearchBot was started")
 
 
 @dataclasses.dataclass
@@ -96,6 +98,10 @@ class FASearchBot:
 
     def start(self):
         start_http_server(7065)
+        info.info({
+            "version": __VERSION__,
+        })
+        start_time.set_to_current_time()
         self.e6_api.login(self.config.e621.username, self.config.e621.api_key)
         self.client = TelegramClient("fasearchbot", self.config.telegram.api_id, self.config.telegram.api_hash)
         self.client.start(bot_token=self.config.telegram.bot_token)

--- a/fa_search_bot/functionalities/beep.py
+++ b/fa_search_bot/functionalities/beep.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 from telethon import events
 
@@ -14,6 +15,10 @@ class BeepFunctionality(BotFunctionality):
 
     async def call(self, event: events.NewMessage.Event) -> None:
         logger.info("Beep")
-        self.usage_counter.inc()
+        self.usage_counter.labels(function="beep").inc()
         await event.respond("boop")
         raise events.StopPropagation
+
+    @property
+    def usage_labels(self) -> List[str]:
+        return ["beep"]

--- a/fa_search_bot/functionalities/beep.py
+++ b/fa_search_bot/functionalities/beep.py
@@ -4,7 +4,6 @@ from telethon import events
 
 from fa_search_bot.functionalities.functionalities import BotFunctionality
 
-usage_logger = logging.getLogger("usage")
 logger = logging.getLogger(__name__)
 
 
@@ -15,6 +14,6 @@ class BeepFunctionality(BotFunctionality):
 
     async def call(self, event: events.NewMessage.Event) -> None:
         logger.info("Beep")
-        usage_logger.info("Beep function")
+        self.usage_counter.inc()
         await event.respond("boop")
         raise events.StopPropagation

--- a/fa_search_bot/functionalities/functionalities.py
+++ b/fa_search_bot/functionalities/functionalities.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from typing import Optional
 
+from prometheus_client import Counter
 from telethon import TelegramClient
 from telethon.events import NewMessage, StopPropagation
 from telethon.events.common import EventCommon, EventBuilder
@@ -28,6 +29,10 @@ class BotFunctionality(ABC):
 
     def __init__(self, event: EventBuilder):
         self.event = event
+        self.usage_counter = Counter(
+            "fasearchbot_usage_total",
+            "Total usage of bot features"
+        ).labels(function_class=self.__class__.__name__)
 
     def register(self, client: TelegramClient) -> None:
         client.add_event_handler(self.call, self.event)

--- a/fa_search_bot/functionalities/functionalities.py
+++ b/fa_search_bot/functionalities/functionalities.py
@@ -1,11 +1,17 @@
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
-from typing import Optional
+from typing import Optional, List
 
 from prometheus_client import Counter
 from telethon import TelegramClient
 from telethon.events import NewMessage, StopPropagation
 from telethon.events.common import EventCommon, EventBuilder
+
+usage_counter = Counter(
+    "fasearchbot_usage_total",
+    "Total usage of bot features",
+    labelnames=["function"]
+)
 
 
 @asynccontextmanager
@@ -29,14 +35,16 @@ class BotFunctionality(ABC):
 
     def __init__(self, event: EventBuilder):
         self.event = event
-        self.usage_counter = Counter(
-            "fasearchbot_usage_total",
-            "Total usage of bot features"
-        ).labels(function_class=self.__class__.__name__)
+        self.usage_counter = usage_counter
 
     def register(self, client: TelegramClient) -> None:
         client.add_event_handler(self.call, self.event)
 
     @abstractmethod
     async def call(self, event: EventCommon) -> None:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def usage_labels(self) -> List[str]:
         raise NotImplementedError

--- a/fa_search_bot/functionalities/image_hash_recommend.py
+++ b/fa_search_bot/functionalities/image_hash_recommend.py
@@ -5,7 +5,6 @@ from telethon.events import NewMessage, StopPropagation
 from fa_search_bot.filters import filter_image_no_caption
 from fa_search_bot.functionalities.functionalities import BotFunctionality
 
-usage_logger = logging.getLogger("usage")
 logger = logging.getLogger(__name__)
 
 
@@ -17,7 +16,7 @@ class ImageHashRecommendFunctionality(BotFunctionality):
 
     async def call(self, event: NewMessage.Event):
         if event.is_private:
-            usage_logger.info("Image hash recommend")
+            self.usage_counter.inc()
             logger.info("Recommending image hash bots")
             await event.reply(
                 "I can't find an image without a link, try using @FindFurryPicBot or @FoxBot. "

--- a/fa_search_bot/functionalities/image_hash_recommend.py
+++ b/fa_search_bot/functionalities/image_hash_recommend.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 from telethon.events import NewMessage, StopPropagation
 
@@ -16,10 +17,14 @@ class ImageHashRecommendFunctionality(BotFunctionality):
 
     async def call(self, event: NewMessage.Event):
         if event.is_private:
-            self.usage_counter.inc()
+            self.usage_counter.labels(function="image_hash_recommend").inc()
             logger.info("Recommending image hash bots")
             await event.reply(
                 "I can't find an image without a link, try using @FindFurryPicBot or @FoxBot. "
                 "For gifs, try @reverseSearchBot."
             )
             raise StopPropagation
+
+    @property
+    def usage_labels(self) -> List[str]:
+        return ["image_hash_recommend"]

--- a/fa_search_bot/functionalities/inline_edit.py
+++ b/fa_search_bot/functionalities/inline_edit.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict
+from typing import Dict, List
 
 from telethon import TelegramClient
 from telethon.events import Raw, CallbackQuery
@@ -18,8 +18,12 @@ class InlineEditFunctionality(BotFunctionality):
         self.handlers = handlers
         self.client = client
 
+    @property
+    def usage_labels(self) -> List[str]:
+        return ["inline_edit"]
+
     async def call(self, event: UpdateBotInlineSend) -> None:
-        self.usage_counter.inc()
+        self.usage_counter.labels(function="inline_edit").inc()
         id_split = event.id.split(":")
         site_id = "fa"
         if len(id_split) == 2:
@@ -40,11 +44,15 @@ class InlineEditButtonPress(BotFunctionality):
         super().__init__(CallbackQuery(pattern="^neaten_me:"))
         self.handlers = handlers
 
+    @property
+    def usage_labels(self) -> List[str]:
+        return ["inline_edit_button"]
+
     async def call(self, event: CallbackQuery) -> None:
         data = event.data.decode()
         if not data.startswith("neaten_me:"):
             return
-        self.usage_counter.inc()
+        self.usage_counter.labels(function="inline_edit_button").inc()
         data_split = data.split(":")
         sub_id = int(data_split[-1])
         site_id = "fa"

--- a/fa_search_bot/functionalities/inline_edit.py
+++ b/fa_search_bot/functionalities/inline_edit.py
@@ -8,7 +8,6 @@ from telethon.tl.types import UpdateBotInlineSend
 from fa_search_bot.functionalities.functionalities import BotFunctionality
 from fa_search_bot.sites.site_handler import SiteHandler
 
-usage_logger = logging.getLogger("usage")
 logger = logging.getLogger(__name__)
 
 
@@ -20,7 +19,7 @@ class InlineEditFunctionality(BotFunctionality):
         self.client = client
 
     async def call(self, event: UpdateBotInlineSend) -> None:
-        usage_logger.info("Updating inline result")
+        self.usage_counter.inc()
         id_split = event.id.split(":")
         site_id = "fa"
         if len(id_split) == 2:
@@ -45,7 +44,7 @@ class InlineEditButtonPress(BotFunctionality):
         data = event.data.decode()
         if not data.startswith("neaten_me:"):
             return
-        usage_logger.info("Inline result update button clicked")
+        self.usage_counter.inc()
         data_split = data.split(":")
         sub_id = int(data_split[-1])
         site_id = "fa"

--- a/fa_search_bot/functionalities/inline_neaten.py
+++ b/fa_search_bot/functionalities/inline_neaten.py
@@ -9,15 +9,19 @@ from fa_search_bot.sites.site_handler import SiteHandler
 from fa_search_bot.utils import gather_ignore_exceptions
 from fa_search_bot.sites.fa_export_api import APIException
 
-usage_logger = logging.getLogger("usage")
 logger = logging.getLogger(__name__)
 
 
 class InlineNeatenFunctionality(BotFunctionality):
+    USE_CASE_ID = "id"
+    USE_CASE_LINK = "link"
 
     def __init__(self, handlers: Dict[str, SiteHandler]) -> None:
         super().__init__(InlineQuery())
         self.handlers = handlers
+        self.usage_counter.labels(use_case=self.USE_CASE_ID)
+        for handler in self.handlers.values():
+            self.usage_counter.labels(use_case=self.USE_CASE_LINK, site_code=handler.site_code)
 
     async def call(self, event: InlineQuery.Event):
         query = event.query.query
@@ -26,7 +30,7 @@ class InlineNeatenFunctionality(BotFunctionality):
         if any(handler.is_valid_submission_id(query_clean) for handler in self.handlers.values()):
             results = await self._answer_id_query(event, query_clean)
             if results:
-                usage_logger.info("Inline submission ID query")
+                self.usage_counter.labels(use_case=self.USE_CASE_ID).inc()
                 logger.info("Sending inline ID query result")
                 await event.answer(results, gallery=True)
                 raise StopPropagation
@@ -36,7 +40,7 @@ class InlineNeatenFunctionality(BotFunctionality):
             if link_matches:
                 results = await self._answer_link_query(event, handler, link_matches)
                 if results:
-                    usage_logger.info("Inline submission link query")
+                    self.usage_counter.labels(use_case=self.USE_CASE_LINK, site_code=handler.site_code).inc()
                     logger.info("Sending inline link query results")
                     await event.answer(results, gallery=isinstance(results[0], InputBotInlineResultPhoto))
                     raise StopPropagation

--- a/fa_search_bot/functionalities/inline_neaten.py
+++ b/fa_search_bot/functionalities/inline_neaten.py
@@ -13,15 +13,18 @@ logger = logging.getLogger(__name__)
 
 
 class InlineNeatenFunctionality(BotFunctionality):
-    USE_CASE_ID = "id"
-    USE_CASE_LINK = "link"
+    USE_CASE_ID = "inline_neaten_id"
+    USE_CASE_LINK = "inline_neaten_link"
 
     def __init__(self, handlers: Dict[str, SiteHandler]) -> None:
         super().__init__(InlineQuery())
         self.handlers = handlers
-        self.usage_counter.labels(use_case=self.USE_CASE_ID)
-        for handler in self.handlers.values():
-            self.usage_counter.labels(use_case=self.USE_CASE_LINK, site_code=handler.site_code)
+
+    @property
+    def usage_labels(self) -> List[str]:
+        return [self.USE_CASE_ID] + [
+            f"{self.USE_CASE_LINK}_{handler.site_code}" for handler in self.handlers.values()
+        ]
 
     async def call(self, event: InlineQuery.Event):
         query = event.query.query
@@ -30,7 +33,7 @@ class InlineNeatenFunctionality(BotFunctionality):
         if any(handler.is_valid_submission_id(query_clean) for handler in self.handlers.values()):
             results = await self._answer_id_query(event, query_clean)
             if results:
-                self.usage_counter.labels(use_case=self.USE_CASE_ID).inc()
+                self.usage_counter.labels(function=f"{self.USE_CASE_ID}").inc()
                 logger.info("Sending inline ID query result")
                 await event.answer(results, gallery=True)
                 raise StopPropagation
@@ -40,7 +43,7 @@ class InlineNeatenFunctionality(BotFunctionality):
             if link_matches:
                 results = await self._answer_link_query(event, handler, link_matches)
                 if results:
-                    self.usage_counter.labels(use_case=self.USE_CASE_LINK, site_code=handler.site_code).inc()
+                    self.usage_counter.labels(function=f"{self.USE_CASE_LINK}_{handler.site_code}").inc()
                     logger.info("Sending inline link query results")
                     await event.answer(results, gallery=isinstance(results[0], InputBotInlineResultPhoto))
                     raise StopPropagation

--- a/fa_search_bot/functionalities/neaten.py
+++ b/fa_search_bot/functionalities/neaten.py
@@ -11,7 +11,6 @@ from fa_search_bot.filters import filter_regex
 from fa_search_bot.functionalities.functionalities import BotFunctionality, in_progress_msg
 from fa_search_bot.sites.site_handler import HandlerException, SiteHandler
 
-usage_logger = logging.getLogger("usage")
 logger = logging.getLogger(__name__)
 
 
@@ -36,6 +35,8 @@ class NeatenFunctionality(BotFunctionality):
             re.IGNORECASE
         )
         super().__init__(NewMessage(func=lambda e: filter_regex(e, link_regex), incoming=True))
+        for handler in handlers.values():
+            self.usage_counter.labels(site_id=handler.site_code)
 
     async def call(self, event: NewMessage.Event):
         # Only deal with messages, not channel posts
@@ -94,7 +95,7 @@ class NeatenFunctionality(BotFunctionality):
 
     async def _handle_submission_link(self, event: NewMessage.Event, sub_id: SubmissionID):
         logger.info("Found a link, ID: %s", sub_id)
-        usage_logger.info("Sending neatened submission")
+        self.usage_counter.labels(site_id=sub_id.site_id).inc()
         handler = self.handlers.get(sub_id.site_id)
         if handler is None:
             return

--- a/fa_search_bot/functionalities/neaten.py
+++ b/fa_search_bot/functionalities/neaten.py
@@ -35,8 +35,10 @@ class NeatenFunctionality(BotFunctionality):
             re.IGNORECASE
         )
         super().__init__(NewMessage(func=lambda e: filter_regex(e, link_regex), incoming=True))
-        for handler in handlers.values():
-            self.usage_counter.labels(site_id=handler.site_code)
+
+    @property
+    def usage_labels(self) -> List[str]:
+        return [f"neaten_{handler.site_code}" for handler in self.handlers.values()]
 
     async def call(self, event: NewMessage.Event):
         # Only deal with messages, not channel posts
@@ -95,7 +97,7 @@ class NeatenFunctionality(BotFunctionality):
 
     async def _handle_submission_link(self, event: NewMessage.Event, sub_id: SubmissionID):
         logger.info("Found a link, ID: %s", sub_id)
-        self.usage_counter.labels(site_id=sub_id.site_id).inc()
+        self.usage_counter.labels(function=f"neaten_{sub_id.site_id}").inc()
         handler = self.handlers.get(sub_id.site_id)
         if handler is None:
             return

--- a/fa_search_bot/functionalities/subscriptions.py
+++ b/fa_search_bot/functionalities/subscriptions.py
@@ -1,6 +1,7 @@
 import html
 import logging
 import re
+from typing import List
 
 from telethon.events import NewMessage, StopPropagation
 
@@ -17,26 +18,31 @@ class SubscriptionFunctionality(BotFunctionality):
     list_sub_cmd = "list_subscriptions"
     pause_cmds = ["pause", "suspend"]
     resume_cmds = ["unpause", "resume"]
-    USE_CASE_ADD = "add subscription"
-    USE_CASE_REMOVE = "remove subscription"
-    USE_CASE_LIST = "list subscriptions"
-    USE_CASE_PAUSE_DEST = "pause destination"
-    USE_CASE_PAUSE_SUB = "pause subscription"
-    USE_CASE_RESUME_DEST = "resume destination"
-    USE_CASE_RESUME_SUB = "resume subscription"
+    USE_CASE_ADD = "subscription_add"
+    USE_CASE_REMOVE = "subscription_remove"
+    USE_CASE_LIST = "subscription_list"
+    USE_CASE_PAUSE_DEST = "subscription_dest_pause"
+    USE_CASE_PAUSE_SUB = "subscription_pause"
+    USE_CASE_RESUME_DEST = "subscription_dest_resume"
+    USE_CASE_RESUME_SUB = "subscription_resume"
 
     def __init__(self, watcher: SubscriptionWatcher):
         commands = [self.add_sub_cmd, self.remove_sub_cmd, self.list_sub_cmd] + self.pause_cmds + self.resume_cmds
         commands_pattern = re.compile(r"^/(" + "|".join(re.escape(c) for c in commands) + ")")
         super().__init__(NewMessage(pattern=commands_pattern, incoming=True))
         self.watcher = watcher
-        self.usage_counter.labels(use_case=self.USE_CASE_ADD)
-        self.usage_counter.labels(use_case=self.USE_CASE_REMOVE)
-        self.usage_counter.labels(use_case=self.USE_CASE_LIST)
-        self.usage_counter.labels(use_case=self.USE_CASE_PAUSE_DEST)
-        self.usage_counter.labels(use_case=self.USE_CASE_PAUSE_SUB)
-        self.usage_counter.labels(use_case=self.USE_CASE_RESUME_DEST)
-        self.usage_counter.labels(use_case=self.USE_CASE_RESUME_SUB)
+
+    @property
+    def usage_labels(self) -> List[str]:
+        return [
+            self.USE_CASE_ADD,
+            self.USE_CASE_REMOVE,
+            self.USE_CASE_LIST,
+            self.USE_CASE_PAUSE_DEST,
+            self.USE_CASE_PAUSE_SUB,
+            self.USE_CASE_RESUME_DEST,
+            self.USE_CASE_RESUME_SUB
+        ]
 
     async def call(self, event: NewMessage.Event):
         message_text = event.text
@@ -67,7 +73,7 @@ class SubscriptionFunctionality(BotFunctionality):
             return "I do not understand."
 
     def _add_sub(self, destination: int, query: str):
-        self.usage_counter.labels(use_case=self.USE_CASE_ADD).inc()
+        self.usage_counter.labels(function=self.USE_CASE_ADD).inc()
         if query == "":
             return f"Please specify the subscription query you wish to add."
         try:
@@ -81,7 +87,7 @@ class SubscriptionFunctionality(BotFunctionality):
         return f"Added subscription: \"{html.escape(query)}\".\n{self._list_subs(destination)}"
 
     def _remove_sub(self, destination: int, query: str):
-        self.usage_counter.labels(use_case=self.USE_CASE_REMOVE).inc()
+        self.usage_counter.labels(function=self.USE_CASE_REMOVE).inc()
         old_sub = Subscription(query, destination)
         try:
             self.watcher.subscriptions.remove(old_sub)
@@ -90,7 +96,7 @@ class SubscriptionFunctionality(BotFunctionality):
             return f"There is not a subscription for \"{html.escape(query)}\" in this chat."
 
     def _list_subs(self, destination: int):
-        self.usage_counter.labels(use_case=self.USE_CASE_LIST).inc()
+        self.usage_counter.labels(function=self.USE_CASE_LIST).inc()
         subs = [sub for sub in self.watcher.subscriptions if sub.destination == destination]
         subs.sort(key=lambda sub: sub.query_str.casefold())
         sub_list_entries = []
@@ -103,7 +109,7 @@ class SubscriptionFunctionality(BotFunctionality):
         return f"Current subscriptions in this chat:\n{subs_list}"
 
     def _pause_destination(self, chat_id: int):
-        self.usage_counter.labels(use_case=self.USE_CASE_PAUSE_DEST).inc()
+        self.usage_counter.labels(function=self.USE_CASE_PAUSE_DEST).inc()
         subs = [sub for sub in self.watcher.subscriptions if sub.destination == chat_id]
         if not subs:
             return "There are no subscriptions posting here to pause."
@@ -115,7 +121,7 @@ class SubscriptionFunctionality(BotFunctionality):
         return f"Paused all subscriptions.\n{self._list_subs(chat_id)}"
 
     def _pause_subscription(self, chat_id: int, sub_name: str):
-        self.usage_counter.labels(use_case=self.USE_CASE_PAUSE_SUB).inc()
+        self.usage_counter.labels(function=self.USE_CASE_PAUSE_SUB).inc()
         pause_sub = Subscription(sub_name, chat_id)
         if pause_sub not in self.watcher.subscriptions:
             return f"There is not a subscription for \"{html.escape(sub_name)}\" in this chat."
@@ -126,7 +132,7 @@ class SubscriptionFunctionality(BotFunctionality):
         return f"Paused subscription: \"{html.escape(sub_name)}\".\n{self._list_subs(chat_id)}"
 
     def _resume_destination(self, chat_id: int) -> str:
-        self.usage_counter.labels(use_case=self.USE_CASE_RESUME_DEST).inc()
+        self.usage_counter.labels(function=self.USE_CASE_RESUME_DEST).inc()
         subs = [sub for sub in self.watcher.subscriptions if sub.destination == chat_id]
         if not subs:
             return "There are no subscriptions posting here to resume."
@@ -138,7 +144,7 @@ class SubscriptionFunctionality(BotFunctionality):
         return f"Resumed all subscriptions.\n{self._list_subs(chat_id)}"
 
     def _resume_subscription(self, chat_id: int, sub_name: str) -> str:
-        self.usage_counter.labels(use_case=self.USE_CASE_RESUME_SUB).inc()
+        self.usage_counter.labels(function=self.USE_CASE_RESUME_SUB).inc()
         pause_sub = Subscription(sub_name, chat_id)
         if pause_sub not in self.watcher.subscriptions:
             return f"There is not a subscription for \"{html.escape(sub_name)}\" in this chat."
@@ -153,18 +159,23 @@ class BlocklistFunctionality(BotFunctionality):
     add_block_tag_cmd = "add_blocklisted_tag"
     remove_block_tag_cmd = "remove_blocklisted_tag"
     list_block_tag_cmd = "list_blocklisted_tags"
-    USE_CASE_ADD = "add block"
-    USE_CASE_REMOVE = "remove block"
-    USE_CASE_LIST = "list blocks"
+    USE_CASE_ADD = "block_add"
+    USE_CASE_REMOVE = "block_remove"
+    USE_CASE_LIST = "block_list"
 
     def __init__(self, watcher: SubscriptionWatcher):
         commands = [self.add_block_tag_cmd, self.remove_block_tag_cmd, self.list_block_tag_cmd]
         commands_pattern = re.compile(r"^/(" + "|".join(re.escape(c) for c in commands) + ")")
         super().__init__(NewMessage(pattern=commands_pattern, incoming=True))
         self.watcher = watcher
-        self.usage_counter.labels(use_case=self.USE_CASE_ADD)
-        self.usage_counter.labels(use_case=self.USE_CASE_REMOVE)
-        self.usage_counter.labels(use_case=self.USE_CASE_LIST)
+
+    @property
+    def usage_labels(self) -> List[str]:
+        return [
+            self.USE_CASE_ADD,
+            self.USE_CASE_REMOVE,
+            self.USE_CASE_LIST
+        ]
 
     async def call(self, event: NewMessage.Event):
         message_text = event.text
@@ -190,7 +201,7 @@ class BlocklistFunctionality(BotFunctionality):
         raise StopPropagation
 
     def _add_to_blocklist(self, destination: int, query: str):
-        self.usage_counter.labels(use_case=self.USE_CASE_ADD).inc()
+        self.usage_counter.labels(function=self.USE_CASE_ADD).inc()
         if query == "":
             return f"Please specify the tag you wish to add to blocklist."
         try:
@@ -200,7 +211,7 @@ class BlocklistFunctionality(BotFunctionality):
         return f"Added tag to blocklist: \"{query}\".\n{self._list_blocklisted_tags(destination)}"
 
     def _remove_from_blocklist(self, destination: int, query: str):
-        self.usage_counter.labels(use_case=self.USE_CASE_REMOVE).inc()
+        self.usage_counter.labels(function=self.USE_CASE_REMOVE).inc()
         try:
             self.watcher.blocklists.get(destination, []).remove(query)
             return f"Removed tag from blocklist: \"{query}\".\n{self._list_blocklisted_tags(destination)}"
@@ -208,7 +219,7 @@ class BlocklistFunctionality(BotFunctionality):
             return f"The tag \"{query}\" is not on the blocklist for this chat."
 
     def _list_blocklisted_tags(self, destination: int):
-        self.usage_counter.labels(use_case=self.USE_CASE_LIST).inc()
+        self.usage_counter.labels(function=self.USE_CASE_LIST).inc()
         blocklist = self.watcher.blocklists.get(destination, [])
         tags_list = "\n".join([f"- {tag}" for tag in blocklist])
         return f"Current blocklist for this chat:\n{tags_list}"

--- a/fa_search_bot/functionalities/subscriptions.py
+++ b/fa_search_bot/functionalities/subscriptions.py
@@ -8,7 +8,6 @@ from fa_search_bot.functionalities.functionalities import BotFunctionality
 from fa_search_bot.query_parser import InvalidQueryException
 from fa_search_bot.subscription_watcher import SubscriptionWatcher, Subscription
 
-usage_logger = logging.getLogger("usage")
 logger = logging.getLogger(__name__)
 
 
@@ -18,12 +17,26 @@ class SubscriptionFunctionality(BotFunctionality):
     list_sub_cmd = "list_subscriptions"
     pause_cmds = ["pause", "suspend"]
     resume_cmds = ["unpause", "resume"]
+    USE_CASE_ADD = "add subscription"
+    USE_CASE_REMOVE = "remove subscription"
+    USE_CASE_LIST = "list subscriptions"
+    USE_CASE_PAUSE_DEST = "pause destination"
+    USE_CASE_PAUSE_SUB = "pause subscription"
+    USE_CASE_RESUME_DEST = "resume destination"
+    USE_CASE_RESUME_SUB = "resume subscription"
 
     def __init__(self, watcher: SubscriptionWatcher):
         commands = [self.add_sub_cmd, self.remove_sub_cmd, self.list_sub_cmd] + self.pause_cmds + self.resume_cmds
         commands_pattern = re.compile(r"^/(" + "|".join(re.escape(c) for c in commands) + ")")
         super().__init__(NewMessage(pattern=commands_pattern, incoming=True))
         self.watcher = watcher
+        self.usage_counter.labels(use_case=self.USE_CASE_ADD)
+        self.usage_counter.labels(use_case=self.USE_CASE_REMOVE)
+        self.usage_counter.labels(use_case=self.USE_CASE_LIST)
+        self.usage_counter.labels(use_case=self.USE_CASE_PAUSE_DEST)
+        self.usage_counter.labels(use_case=self.USE_CASE_PAUSE_SUB)
+        self.usage_counter.labels(use_case=self.USE_CASE_RESUME_DEST)
+        self.usage_counter.labels(use_case=self.USE_CASE_RESUME_SUB)
 
     async def call(self, event: NewMessage.Event):
         message_text = event.text
@@ -54,7 +67,7 @@ class SubscriptionFunctionality(BotFunctionality):
             return "I do not understand."
 
     def _add_sub(self, destination: int, query: str):
-        usage_logger.info("Add subscription")
+        self.usage_counter.labels(use_case=self.USE_CASE_ADD).inc()
         if query == "":
             return f"Please specify the subscription query you wish to add."
         try:
@@ -68,7 +81,7 @@ class SubscriptionFunctionality(BotFunctionality):
         return f"Added subscription: \"{html.escape(query)}\".\n{self._list_subs(destination)}"
 
     def _remove_sub(self, destination: int, query: str):
-        usage_logger.info("Remove subscription")
+        self.usage_counter.labels(use_case=self.USE_CASE_REMOVE).inc()
         old_sub = Subscription(query, destination)
         try:
             self.watcher.subscriptions.remove(old_sub)
@@ -77,7 +90,7 @@ class SubscriptionFunctionality(BotFunctionality):
             return f"There is not a subscription for \"{html.escape(query)}\" in this chat."
 
     def _list_subs(self, destination: int):
-        usage_logger.info("List subscriptions")
+        self.usage_counter.labels(use_case=self.USE_CASE_LIST).inc()
         subs = [sub for sub in self.watcher.subscriptions if sub.destination == destination]
         subs.sort(key=lambda sub: sub.query_str.casefold())
         sub_list_entries = []
@@ -90,7 +103,7 @@ class SubscriptionFunctionality(BotFunctionality):
         return f"Current subscriptions in this chat:\n{subs_list}"
 
     def _pause_destination(self, chat_id: int):
-        usage_logger.info("Pause destination")
+        self.usage_counter.labels(use_case=self.USE_CASE_PAUSE_DEST).inc()
         subs = [sub for sub in self.watcher.subscriptions if sub.destination == chat_id]
         if not subs:
             return "There are no subscriptions posting here to pause."
@@ -102,7 +115,7 @@ class SubscriptionFunctionality(BotFunctionality):
         return f"Paused all subscriptions.\n{self._list_subs(chat_id)}"
 
     def _pause_subscription(self, chat_id: int, sub_name: str):
-        usage_logger.info("Pause subscription")
+        self.usage_counter.labels(use_case=self.USE_CASE_PAUSE_SUB).inc()
         pause_sub = Subscription(sub_name, chat_id)
         if pause_sub not in self.watcher.subscriptions:
             return f"There is not a subscription for \"{html.escape(sub_name)}\" in this chat."
@@ -113,7 +126,7 @@ class SubscriptionFunctionality(BotFunctionality):
         return f"Paused subscription: \"{html.escape(sub_name)}\".\n{self._list_subs(chat_id)}"
 
     def _resume_destination(self, chat_id: int) -> str:
-        usage_logger.info("Resume destination")
+        self.usage_counter.labels(use_case=self.USE_CASE_RESUME_DEST).inc()
         subs = [sub for sub in self.watcher.subscriptions if sub.destination == chat_id]
         if not subs:
             return "There are no subscriptions posting here to resume."
@@ -125,7 +138,7 @@ class SubscriptionFunctionality(BotFunctionality):
         return f"Resumed all subscriptions.\n{self._list_subs(chat_id)}"
 
     def _resume_subscription(self, chat_id: int, sub_name: str) -> str:
-        usage_logger.info("Resume subscription")
+        self.usage_counter.labels(use_case=self.USE_CASE_RESUME_SUB).inc()
         pause_sub = Subscription(sub_name, chat_id)
         if pause_sub not in self.watcher.subscriptions:
             return f"There is not a subscription for \"{html.escape(sub_name)}\" in this chat."
@@ -140,12 +153,18 @@ class BlocklistFunctionality(BotFunctionality):
     add_block_tag_cmd = "add_blocklisted_tag"
     remove_block_tag_cmd = "remove_blocklisted_tag"
     list_block_tag_cmd = "list_blocklisted_tags"
+    USE_CASE_ADD = "add block"
+    USE_CASE_REMOVE = "remove block"
+    USE_CASE_LIST = "list blocks"
 
     def __init__(self, watcher: SubscriptionWatcher):
         commands = [self.add_block_tag_cmd, self.remove_block_tag_cmd, self.list_block_tag_cmd]
         commands_pattern = re.compile(r"^/(" + "|".join(re.escape(c) for c in commands) + ")")
         super().__init__(NewMessage(pattern=commands_pattern, incoming=True))
         self.watcher = watcher
+        self.usage_counter.labels(use_case=self.USE_CASE_ADD)
+        self.usage_counter.labels(use_case=self.USE_CASE_REMOVE)
+        self.usage_counter.labels(use_case=self.USE_CASE_LIST)
 
     async def call(self, event: NewMessage.Event):
         message_text = event.text
@@ -171,6 +190,7 @@ class BlocklistFunctionality(BotFunctionality):
         raise StopPropagation
 
     def _add_to_blocklist(self, destination: int, query: str):
+        self.usage_counter.labels(use_case=self.USE_CASE_ADD).inc()
         if query == "":
             return f"Please specify the tag you wish to add to blocklist."
         try:
@@ -180,6 +200,7 @@ class BlocklistFunctionality(BotFunctionality):
         return f"Added tag to blocklist: \"{query}\".\n{self._list_blocklisted_tags(destination)}"
 
     def _remove_from_blocklist(self, destination: int, query: str):
+        self.usage_counter.labels(use_case=self.USE_CASE_REMOVE).inc()
         try:
             self.watcher.blocklists.get(destination, []).remove(query)
             return f"Removed tag from blocklist: \"{query}\".\n{self._list_blocklisted_tags(destination)}"
@@ -187,6 +208,7 @@ class BlocklistFunctionality(BotFunctionality):
             return f"The tag \"{query}\" is not on the blocklist for this chat."
 
     def _list_blocklisted_tags(self, destination: int):
+        self.usage_counter.labels(use_case=self.USE_CASE_LIST).inc()
         blocklist = self.watcher.blocklists.get(destination, [])
         tags_list = "\n".join([f"- {tag}" for tag in blocklist])
         return f"Current blocklist for this chat:\n{tags_list}"

--- a/fa_search_bot/functionalities/supergroup_upgrade.py
+++ b/fa_search_bot/functionalities/supergroup_upgrade.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 from telethon import events
 from telethon.events import StopPropagation
@@ -23,12 +24,16 @@ class SupergroupUpgradeFunctionality(BotFunctionality):
         super().__init__(events.Raw(types.UpdateNewChannelMessage, func=filter_migration))
         self.watcher = watcher
 
+    @property
+    def usage_labels(self) -> List[str]:
+        return ["supergroup_upgrade"]
+
     async def call(self, event: types.UpdateNewChannelMessage):
         old_chat_id = -1 * event.message.action.chat_id
         new_chat_id = int('-100' + str(event.message.to_id.channel_id))
         # Log the upgrade
         logger.info("Migration from chat ID: %s to chat ID: %s", old_chat_id, new_chat_id)
-        self.usage_counter.inc()
+        self.usage_counter.labels(function="supergroup_upgrade").inc()
         # Upgrade subscriptions and block queries
         self.watcher.migrate_chat(old_chat_id, new_chat_id)
         raise StopPropagation

--- a/fa_search_bot/functionalities/supergroup_upgrade.py
+++ b/fa_search_bot/functionalities/supergroup_upgrade.py
@@ -8,7 +8,6 @@ from telethon.tl.types import UpdateNewChannelMessage
 from fa_search_bot.functionalities.functionalities import BotFunctionality
 from fa_search_bot.subscription_watcher import SubscriptionWatcher
 
-usage_logger = logging.getLogger("usage")
 logger = logging.getLogger(__name__)
 
 
@@ -29,7 +28,7 @@ class SupergroupUpgradeFunctionality(BotFunctionality):
         new_chat_id = int('-100' + str(event.message.to_id.channel_id))
         # Log the upgrade
         logger.info("Migration from chat ID: %s to chat ID: %s", old_chat_id, new_chat_id)
-        usage_logger.info("Supergroup migration")
+        self.usage_counter.inc()
         # Upgrade subscriptions and block queries
         self.watcher.migrate_chat(old_chat_id, new_chat_id)
         raise StopPropagation

--- a/fa_search_bot/functionalities/unhandled.py
+++ b/fa_search_bot/functionalities/unhandled.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 from telethon.events import NewMessage, StopPropagation
 
@@ -12,10 +13,14 @@ class UnhandledMessageFunctionality(BotFunctionality):
     def __init__(self):
         super().__init__(NewMessage(incoming=True))
 
+    @property
+    def usage_labels(self) -> List[str]:
+        return ["unhandled"]
+
     async def call(self, event: NewMessage.Event):
         if event.text is not None and event.is_private:
             logger.info("Unhandled message sent to bot")
-            self.usage_counter.inc()
+            self.usage_counter.labels(function="unhandled").inc()
             await event.reply(
                 "Sorry, I'm not sure how to handle that message",
             )

--- a/fa_search_bot/functionalities/unhandled.py
+++ b/fa_search_bot/functionalities/unhandled.py
@@ -4,7 +4,6 @@ from telethon.events import NewMessage, StopPropagation
 
 from fa_search_bot.functionalities.functionalities import BotFunctionality
 
-usage_logger = logging.getLogger("usage")
 logger = logging.getLogger(__name__)
 
 
@@ -16,7 +15,7 @@ class UnhandledMessageFunctionality(BotFunctionality):
     async def call(self, event: NewMessage.Event):
         if event.text is not None and event.is_private:
             logger.info("Unhandled message sent to bot")
-            usage_logger.info("Unhandled message")
+            self.usage_counter.inc()
             await event.reply(
                 "Sorry, I'm not sure how to handle that message",
             )

--- a/fa_search_bot/functionalities/welcome.py
+++ b/fa_search_bot/functionalities/welcome.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 from telethon.events import NewMessage, StopPropagation
 from telethon.extensions import markdown
@@ -16,7 +17,7 @@ class WelcomeFunctionality(BotFunctionality):
 
     async def call(self, event: NewMessage.Event):
         logger.info("Welcome message sent to user")
-        self.usage_counter.inc()
+        self.usage_counter.labels(function="welcome").inc()
         await event.respond(
             "Hello, I'm a bot to interface with furaffinity through telegram. I can do a few things, "
             "but there's still more for me to learn.\n"
@@ -34,3 +35,7 @@ class WelcomeFunctionality(BotFunctionality):
             parse_mode=markdown
         )
         raise StopPropagation
+
+    @property
+    def usage_labels(self) -> List[str]:
+        return ["welcome"]

--- a/fa_search_bot/functionalities/welcome.py
+++ b/fa_search_bot/functionalities/welcome.py
@@ -6,7 +6,6 @@ from telethon.extensions import markdown
 from fa_search_bot._version import __VERSION__
 from fa_search_bot.functionalities.functionalities import BotFunctionality
 
-usage_logger = logging.getLogger("usage")
 logger = logging.getLogger(__name__)
 
 
@@ -17,7 +16,7 @@ class WelcomeFunctionality(BotFunctionality):
 
     async def call(self, event: NewMessage.Event):
         logger.info("Welcome message sent to user")
-        usage_logger.info("Welcome message")
+        self.usage_counter.inc()
         await event.respond(
             "Hello, I'm a bot to interface with furaffinity through telegram. I can do a few things, "
             "but there's still more for me to learn.\n"

--- a/fa_search_bot/sites/e621_handler.py
+++ b/fa_search_bot/sites/e621_handler.py
@@ -16,11 +16,13 @@ logger = logging.getLogger(__name__)
 
 api_request_times = Histogram(
     "fasearchbot_e6handler_request_time_seconds",
-    "Request times of the e621 API, in seconds"
+    "Request times of the e621 API, in seconds",
+    labelnames=["endpoint"]
 )
 api_failures = Counter(
     "fasearchbot_e6handler_exceptions_total",
-    "Total number of exceptions raised while querying the e621 API"
+    "Total number of exceptions raised while querying the e621 API",
+    labelnames=["endpoint"]
 )
 
 

--- a/fa_search_bot/sites/e621_handler.py
+++ b/fa_search_bot/sites/e621_handler.py
@@ -75,13 +75,13 @@ class E621Handler(SiteHandler):
         if not direct_match:
             return None
         md5_hash = direct_match.group(1)
-        post_id = (await self._find_post_by_hash(md5_hash)).id
-        if not post_id:
+        post = await self._find_post_by_hash(md5_hash)
+        if not post:
             raise HandlerException(
                 f"Could not locate the post with hash {md5_hash}."
             )
         logger.info("e621 link: direct image link")
-        return post_id
+        return post.id
 
     async def _find_post_by_hash(self, md5_hash: str) -> Optional[Post]:
         with api_request_times.labels(endpoint=Endpoint.SEARCH_MD5.value).time():

--- a/fa_search_bot/sites/fa_export_api.py
+++ b/fa_search_bot/sites/fa_export_api.py
@@ -71,7 +71,7 @@ class FAExportAPI:
 
     def _api_request(self, path: str, endpoint_label: Endpoint) -> requests.Response:
         path = path.lstrip("/")
-        with api_request_times.labels(endpoint=endpoint_label.value):
+        with api_request_times.labels(endpoint=endpoint_label.value).time():
             resp = requests.get(f"{self.base_url}/{path}")
         if resp.status_code == 503:
             cloudflare_errors.labels(endpoint=endpoint_label).inc()

--- a/fa_search_bot/sites/fa_export_api.py
+++ b/fa_search_bot/sites/fa_export_api.py
@@ -1,14 +1,35 @@
 import asyncio
+import enum
 import logging
 import datetime
 from typing import List
 
 import requests
+from prometheus_client import Counter, Enum, Histogram
 
 from fa_search_bot.sites.fa_submission import FASubmission, FASubmissionShort, FASubmissionFull, FASubmissionShortFav, \
     FAStatus
 
 logger = logging.getLogger(__name__)
+
+site_slowdown = Enum(
+    "fasearchbot_faapi_slowdown_state",
+    "Whether the FA API is in a slow state due to high number of registered users on FA",
+    states=["slow", "not_slow"]
+)
+cloudflare_errors = Counter(
+    "fasearchbot_faapi_cloudflare_errors_total",
+    "Number of cloudflare errors received by the FA API"
+)
+api_request_times = Histogram(
+    "fasearchbot_faapi_request_time_seconds",
+    "Request times of the FA API, in seconds"
+)
+api_retry_counts = Histogram(
+    "fasearchbot_faapi_retry_counts",
+    "Retry counts of the FA API",
+    buckets=list(range(10))
+)
 
 
 class APIException(Exception):
@@ -23,6 +44,15 @@ class CloudflareError(APIException):
     pass
 
 
+class Endpoint(enum.Enum):
+    SUBMISSION = "submission"
+    USER_FOLDER = "user_folder"
+    USER_FAVS = "user_favs"
+    SEARCH = "search"
+    BROWSE = "browse"
+    STATUS = "status"
+
+
 class FAExportAPI:
     MAX_RETRIES = 7
     STATUS_CHECK_BACKOFF = 60 * 5
@@ -34,23 +64,32 @@ class FAExportAPI:
         self.last_status_check = None
         self.slow_down_status = False
         self.ignore_status = ignore_status
+        for endpoint in Endpoint:
+            cloudflare_errors.labels(endpoint=endpoint.value)
+            api_request_times.labels(endpoint=endpoint.value)
+            api_retry_counts.labels(endpoint=endpoint.value)
 
-    def _api_request(self, path: str) -> requests.Response:
+    def _api_request(self, path: str, endpoint_label: Endpoint) -> requests.Response:
         path = path.lstrip("/")
-        resp = requests.get(f"{self.base_url}/{path}")
+        with api_request_times.labels(endpoint=endpoint_label.value):
+            resp = requests.get(f"{self.base_url}/{path}")
         if resp.status_code == 503:
+            cloudflare_errors.labels(endpoint=endpoint_label).inc()
             raise CloudflareError()
         return resp
 
-    async def _api_request_with_retry(self, path: str) -> requests.Response:
+    async def _api_request_with_retry(self, path: str, endpoint_label: Endpoint) -> requests.Response:
         if self._is_site_slowdown():
             await asyncio.sleep(self.SLOWDOWN_BACKOFF)
-        resp = self._api_request(path)
+        resp = self._api_request(path, endpoint_label)
+        tries = 0
         for tries in range(self.MAX_RETRIES):
             if str(resp.status_code)[0] != "5":
+                api_retry_counts.labels(endpoint=endpoint_label.value).observe(tries)
                 return resp
             await asyncio.sleep(tries ** 2)
-            resp = self._api_request(path)
+            resp = self._api_request(path, endpoint_label)
+        api_retry_counts.labels(endpoint=endpoint_label.value).observe(tries)
         return resp
 
     def _is_site_slowdown(self) -> bool:
@@ -64,11 +103,12 @@ class FAExportAPI:
             status = self.status()
             self.last_status_check = now
             self.slow_down_status = status.online_registered > self.STATUS_LIMIT_REGISTERED
+        site_slowdown.state("slow" if self.slow_down_status else "not_slow")
         return self.slow_down_status
 
     async def get_full_submission(self, submission_id: str) -> FASubmissionFull:
         logger.debug("Getting full submission for submission ID %s", submission_id)
-        sub_resp = await self._api_request_with_retry(f"submission/{submission_id}.json")
+        sub_resp = await self._api_request_with_retry(f"submission/{submission_id}.json", Endpoint.SUBMISSION)
         # If API returns fine
         if sub_resp.status_code == 200:
             submission = FASubmission.from_full_dict(sub_resp.json())
@@ -80,7 +120,7 @@ class FAExportAPI:
         logger.debug("Getting user folder for user %s, folder %s, and page %s", user, folder, page)
         if user.strip() == "":
             raise PageNotFound(f"User not found by name: {user}")
-        resp = await self._api_request_with_retry(f"user/{user}/{folder}.json?page={page}&full=1")
+        resp = await self._api_request_with_retry(f"user/{user}/{folder}.json?page={page}&full=1", Endpoint.USER_FOLDER)
         if resp.status_code == 200:
             data = resp.json()
             submissions = []
@@ -98,7 +138,7 @@ class FAExportAPI:
         next_str = ""
         if next_id is not None:
             next_str = f"next={next_id}&"
-        resp = await self._api_request_with_retry(f"user/{user}/favorites.json?{next_str}full=1")
+        resp = await self._api_request_with_retry(f"user/{user}/favorites.json?{next_str}full=1", Endpoint.USER_FAVS)
         if resp.status_code == 200:
             data = resp.json()
             submissions = []
@@ -111,7 +151,10 @@ class FAExportAPI:
 
     async def get_search_results(self, query: str, page: int = 1) -> List[FASubmissionShort]:
         logger.debug("Searching for query: %s, page: %s", query, page)
-        resp = await self._api_request_with_retry(f"search.json?full=1&perpage=48&q={query}&page={page}")
+        resp = await self._api_request_with_retry(
+            f"search.json?full=1&perpage=48&q={query}&page={page}",
+            Endpoint.SEARCH
+        )
         data = resp.json()
         submissions = []
         for submission_data in data:
@@ -120,7 +163,7 @@ class FAExportAPI:
 
     async def get_browse_page(self, page: int = 1) -> List[FASubmissionShort]:
         logger.debug("Getting browse page %s", page)
-        resp = await self._api_request_with_retry(f"browse.json?page={page}")
+        resp = await self._api_request_with_retry(f"browse.json?page={page}", Endpoint.BROWSE)
         data = resp.json()
         submissions = []
         for submission_data in data:
@@ -130,10 +173,10 @@ class FAExportAPI:
     def status(self) -> FAStatus:
         logger.debug("Getting status page")
         path = "status.json"
-        resp = self._api_request(path)
+        resp = self._api_request(path, Endpoint.STATUS)
         for tries in range(self.MAX_RETRIES):
             if str(resp.status_code)[0] != "5":
                 break
-            resp = self._api_request(path)
+            resp = self._api_request(path, Endpoint.STATUS)
         data = resp.json()
         return FAStatus.from_dict(data)

--- a/fa_search_bot/sites/fa_export_api.py
+++ b/fa_search_bot/sites/fa_export_api.py
@@ -19,16 +19,19 @@ site_slowdown = Enum(
 )
 cloudflare_errors = Counter(
     "fasearchbot_faapi_cloudflare_errors_total",
-    "Number of cloudflare errors received by the FA API"
+    "Number of cloudflare errors received by the FA API",
+    labelnames=["endpoint"]
 )
 api_request_times = Histogram(
     "fasearchbot_faapi_request_time_seconds",
-    "Request times of the FA API, in seconds"
+    "Request times of the FA API, in seconds",
+    labelnames=["endpoint"]
 )
 api_retry_counts = Histogram(
     "fasearchbot_faapi_retry_counts",
     "Retry counts of the FA API",
-    buckets=list(range(10))
+    buckets=list(range(10)),
+    labelnames=["endpoint"]
 )
 
 

--- a/fa_search_bot/sites/fa_submission.py
+++ b/fa_search_bot/sites/fa_submission.py
@@ -1,8 +1,5 @@
-import dataclasses
 import datetime
-import io
 import logging
-import os
 import re
 from abc import ABC
 from enum import Enum
@@ -15,7 +12,6 @@ from telethon.tl.custom import InlineBuilder
 from telethon.tl.types import InputBotInlineResultPhoto
 
 logger = logging.getLogger(__name__)
-usage_logger = logging.getLogger("usage")
 
 
 class Rating(Enum):

--- a/fa_search_bot/sites/sendable.py
+++ b/fa_search_bot/sites/sendable.py
@@ -568,7 +568,7 @@ class Sendable(ABC):
             "entrypoint": DockerEntrypoint.from_string(entrypoint).value
         }
         with docker_run_time.labels(**labels).time():
-            with docker_failures.labels(**labels).count_exception():
+            with docker_failures.labels(**labels).count_exceptions():
                 sandbox_dir = os.getcwd() + "/sandbox"
                 logger.debug("Running docker container with args %s and entrypoint %s", args, entrypoint)
                 container: Container = client.containers.run(

--- a/fa_search_bot/sites/sendable.py
+++ b/fa_search_bot/sites/sendable.py
@@ -27,114 +27,140 @@ logger = logging.getLogger(__name__)
 
 sendable_sent = Counter(
     "fasearchbot_sendable_sent_message_total",
-    "Number of submissions sent or edited, labelled by site"
+    "Number of submissions sent or edited, labelled by site",
+    labelnames=["site_code"]
 )
 sendable_gif_to_png = Counter(
     "fasearchbot_sendable_convert_gif_to_png_total",
-    "Number of images which were converted from static gif to png"
+    "Number of images which were converted from static gif to png",
+    labelnames=["site_code"]
 )
 sendable_edit = Counter(
     "fasearchbot_sendable_edit_total",
-    "Number of submissions which were sent as an edit"
+    "Number of submissions which were sent as an edit",
+    labelnames=["site_code"]
 )
 sendable_failure = Counter(
     "fasearchbot_sendable_exception_total",
-    "Number of sendable attempts which raised an exception"
+    "Number of sendable attempts which raised an exception",
+    labelnames=["site_code"]
 )
 sendable_image = Counter(
     "fasearchbot_sendable_image_total",
-    "Number of static images which were sent"
+    "Number of static images which were sent",
+    labelnames=["site_code"]
 )
 sendable_animated = Counter(
     "fasearchbot_sendable_animated_total",
-    "Number of animated images and videos which were sent"
+    "Number of animated images and videos which were sent",
+    labelnames=["site_code"]
 )
 sendable_animated_cached = Counter(
     "fasearchbot_sendable_animated_cached_total",
-    "Number of animated images and videos which were sent from file cache"
+    "Number of animated images and videos which were sent from file cache",
+    labelnames=["site_code"]
 )
 sendable_auto_doc = Counter(
     "fasearchbot_sendable_auto_document_total",
-    "Number of documents sent which telegram can automatically handle"
+    "Number of documents sent which telegram can automatically handle",
+    labelnames=["site_code"]
 )
 sendable_audio = Counter(
     "fasearchbot_sendable_audio_total",
-    "Number of audio files which were sent"
+    "Number of audio files which were sent",
+    labelnames=["site_code"]
 )
 sendable_other = Counter(
     "fasearchbot_sendable_other_files_total",
-    "Number of files sent which had no special handling"
+    "Number of files sent which had no special handling",
+    labelnames=["site_code"]
 )
 
 convert_video_total = Counter(
     "fasearchbot_convert_video_total",
-    "Number of animated images or videos which we tried to process"
+    "Number of animated images or videos which we tried to process",
+    labelnames=["site_code"]
 )
 convert_video_failures = Counter(
     "fasearchbot_convert_video_exception_total",
-    "Number of video conversions which raised an exception"
+    "Number of video conversions which raised an exception",
+    labelnames=["site_code"]
 )
 convert_video_animated = Counter(
     "fasearchbot_convert_video_animated_total",
-    "Number of animated images which we tried to convert to a video"
+    "Number of animated images which we tried to convert to a video",
+    labelnames=["site_code"]
 )
 convert_video_no_audio = Counter(
     "fasearchbot_convert_video_no_audio_total",
-    "Number of videos without audio which we tried to convert"
+    "Number of videos without audio which we tried to convert",
+    labelnames=["site_code"]
 )
 convert_video_no_audio_gif = Counter(
     "fasearchbot_convert_video_no_audio_gif_total",
-    "Number of videos without audio which we tried to convert to a telegram gif"
+    "Number of videos without audio which we tried to convert to a telegram gif",
+    labelnames=["site_code"]
 )
 convert_video_to_video = Counter(
     "fasearchbot_convert_video_to_video_total",
-    "Number of videos which we tried to convert into a video with audio"
+    "Number of videos which we tried to convert into a video with audio",
+    labelnames=["site_code"]
 )
 convert_video_only_one_attempt = Counter(
     "fasearchbot_convert_video_only_one_attempt_total",
-    "Number of videos which we converted with a one-pass conversion attempt"
+    "Number of videos which we converted with a one-pass conversion attempt",
+    labelnames=["site_code"]
 )
 convert_video_two_pass = Counter(
     "fasearchbot_convert_video_two_pass_total",
-    "Number of videos which required a two-pass conversion to fit within telegram limits"
+    "Number of videos which required a two-pass conversion to fit within telegram limits",
+    labelnames=["site_code"]
 )
 
 convert_gif_total = Counter(
     "fasearchbot_convert_gif_total",
-    "Number of animated images or short silent videos we tried to convert into telegram gifs"
+    "Number of animated images or short silent videos we tried to convert into telegram gifs",
+    labelnames=["site_code"]
 )
 convert_gif_failures = Counter(
     "fasearchbot_convert_gif_exception_total",
-    "Number of telegram gif conversions which raised an exception"
+    "Number of telegram gif conversions which raised an exception",
+    labelnames=["site_code"]
 )
 convert_gif_only_one_attempt = Counter(
     "fasearchbot_convert_gif_only_one_attempt_total",
-    "Number of telegram gifs which required only one-pass conversion"
+    "Number of telegram gifs which required only one-pass conversion",
+    labelnames=["site_code"]
 )
 convert_gif_two_pass = Counter(
     "fasearchbot_convert_gif_two_pass_total",
-    "Number of telegram gifs which required two-pass conversion to fit within telegram limits"
+    "Number of telegram gifs which required two-pass conversion to fit within telegram limits",
+    labelnames=["site_code"]
 )
 
 video_length = Histogram(
     "fasearchbot_video_length_seconds",
     "Length of the videos processed by the bot, in seconds",
-    buckets=[1, 2, 5, 10, 30, 60, 120, 300, 600, 1200, float("inf")]
+    buckets=[1, 2, 5, 10, 30, 60, 120, 300, 600, 1200, float("inf")],
+    labelnames=["site_code"]
 )
 
 docker_run_time = Histogram(
     "fasearchbot_docker_runtime_seconds",
     "Time the docker image took to run and return, in seconds",
-    buckets=[0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600, float("inf")]
+    buckets=[0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600, float("inf")],
+    labelnames=["site_code", "entrypoint"]
 )
 docker_failures = Counter(
     "fasearchbot_docker_failure_total",
-    "Number of times an exception was raised while running a docker image"
+    "Number of times an exception was raised while running a docker image",
+    labelnames=["site_code", "entrypoint"]
 )
 
 inline_results = Counter(
     "fasearchbot_sendable_inline_result_total",
-    "Total number of inline results sent"
+    "Total number of inline results sent",
+    labelnames=["site_code"]
 )
 
 

--- a/fa_search_bot/sites/sendable.py
+++ b/fa_search_bot/sites/sendable.py
@@ -24,7 +24,6 @@ from telethon.tl.types import TypeInputPeer, InputBotInlineResultPhoto
 from fa_search_bot.sites.site_handler import SiteHandler
 
 logger = logging.getLogger(__name__)
-usage_logger = logging.getLogger("usage")
 
 sendable_sent = Counter(
     "fasearchbot_sendable_sent_message_total",
@@ -410,7 +409,6 @@ class Sendable(ABC):
         filename = f"{cache_dir}/{self.id}.mp4"
         if os.path.exists(filename):
             logger.info("Loading video from cache, site ID %s, submission ID %s", self.site_id, self.id)
-            usage_logger.info("Pretty video: from cache")
             return filename
         return None
 
@@ -424,7 +422,6 @@ class Sendable(ABC):
     @_count_exceptions_with_labels(convert_gif_failures)
     async def _convert_gif(self, gif_url: str) -> str:
         convert_gif_total.labels(site_code=self.site_id).inc()
-        usage_logger.info("Pretty gif: converting")
         ffmpeg_options = " -an -vcodec libx264 -tune animation -preset veryslow -movflags faststart -pix_fmt yuv420p " \
                          "-vf \"scale='min(1280,iw)':'min(1280,ih)':force_original_aspect_" \
                          "ratio=decrease,scale=trunc(iw/2)*2:trunc(ih/2)*2\" -profile:v baseline -level 3.0 -vsync vfr"
@@ -448,7 +445,6 @@ class Sendable(ABC):
         if video_url.split(".")[-1].lower() in self.EXTENSIONS_ANIMATED:
             convert_video_animated.labels(site_code=self.site_id).inc()
             return await self._convert_gif(video_url)
-        usage_logger.info("Pretty video: converting")
         client = docker.from_env()
         ffmpeg_options = "-qscale 0"
         ffmpeg_prefix = ""

--- a/fa_search_bot/sites/sendable.py
+++ b/fa_search_bot/sites/sendable.py
@@ -567,8 +567,8 @@ class Sendable(ABC):
             "site_code": self.site_id,
             "entrypoint": DockerEntrypoint.from_string(entrypoint).value
         }
-        with docker_run_time.labels(labels).time():
-            with docker_failures.labels(labels).count_exception():
+        with docker_run_time.labels(**labels).time():
+            with docker_failures.labels(**labels).count_exception():
                 sandbox_dir = os.getcwd() + "/sandbox"
                 logger.debug("Running docker container with args %s and entrypoint %s", args, entrypoint)
                 container: Container = client.containers.run(

--- a/fa_search_bot/sites/sendable.py
+++ b/fa_search_bot/sites/sendable.py
@@ -228,10 +228,10 @@ def _convert_gif_to_png(file_url: str) -> bytes:
 
 def _count_exceptions_with_labels(counter: Counter):
     def _count_exceptions(f):
-        def wrapper(*args):
+        async def wrapper(*args, **kwargs):
             self = args[0]
             with counter.labels(site_code=self.site_id).count_exceptions():
-                return f(*args)
+                return await f(*args, **kwargs)
 
         return wrapper
 

--- a/fa_search_bot/subscription_watcher.py
+++ b/fa_search_bot/subscription_watcher.py
@@ -66,6 +66,22 @@ latest_sub_processed = Gauge(
     "fasearchbot_fasubwatcher_latest_processed_unixtime",
     "Time that the latest submission was processed"
 )
+gauge_sub = Gauge(
+    "fasearchbot_fasubwatcher_subscription_count",
+    "Total number of subscriptions"
+)
+gauge_subs_active = Gauge(
+    "fasearchbot_fasubwatcher_subscription_count_active",
+    "Number of active subscriptions"
+)
+gauge_sub_destinations = Gauge(
+    "fasearchbot_fasubwatcher_subscription_destination_count",
+    "Number of different subscription destinations"
+)
+gauge_sub_blocks = Gauge(
+    "fasearchbot_fasubwatcher_subscription_block_query_count",
+    "Total number of blocklist queries"
+)
 
 
 class SubscriptionWatcher:
@@ -84,13 +100,9 @@ class SubscriptionWatcher:
         self.subscriptions = set()  # type: Set[Subscription]
         self.blocklists = dict()  # type: Dict[int, Set[str]]
         self.blocklist_query_cache = dict()  # type: Dict[str, Query]
-        gauge_sub = Gauge("sub_count", "Number of subscriptions")
         gauge_sub.set_function(lambda: len(self.subscriptions))
-        gauge_subs_active = Gauge("sub_count_active", "Number of active subscriptions")
         gauge_subs_active.set_function(lambda: len([s for s in self.subscriptions if not s.paused]))
-        gauge_sub_destinations = Gauge("sub_count_dests", "Number of different subscription destinations")
         gauge_sub_destinations.set_function(lambda: len(set(s.destination for s in self.subscriptions)))
-        gauge_sub_blocks = Gauge("sub_count_blocks", "Total number of blocklist queries")
         gauge_sub_blocks.set_function(lambda: sum(len(blocks) for blocks in self.blocklists.values()))
 
     async def run(self):

--- a/fa_search_bot/subscription_watcher.py
+++ b/fa_search_bot/subscription_watcher.py
@@ -27,7 +27,7 @@ subs_processed = Counter(
     "Total number of submissions processed by the subscription watcher"
 )
 subs_failed = Counter(
-    "fasearchbot_fasubwatcher_other_failed_total",
+    "fasearchbot_fasubwatcher_submissions_failed_total",
     "Number of submissions for which the sub watcher failed to get data, for any reason"
 )
 subs_not_found = Counter(

--- a/fa_search_bot/subscription_watcher.py
+++ b/fa_search_bot/subscription_watcher.py
@@ -82,6 +82,10 @@ gauge_sub_blocks = Gauge(
     "fasearchbot_fasubwatcher_subscription_block_query_count",
     "Total number of blocklist queries"
 )
+gauge_backlog = Gauge(
+    "fasearchbot_fasubwatcher_backlog",
+    "Length of the latest list of new submissions to check"
+)
 
 
 class SubscriptionWatcher:
@@ -110,7 +114,6 @@ class SubscriptionWatcher:
         This method is launched as a task, it reads the browse endpoint for new submissions, and checks if they
         match existing subscriptions
         """
-        gauge_backlog = Gauge("watcher_backlog", "Length of the latest list of new submissions to check")
         self.running = True
         while self.running:
             try:

--- a/fa_search_bot/subscription_watcher.py
+++ b/fa_search_bot/subscription_watcher.py
@@ -22,7 +22,6 @@ heartbeat.heartbeat_app_url = "https://heartbeat.spangle.org.uk/"
 heartbeat_app_name = "FASearchBot_sub_thread"
 
 logger = logging.getLogger(__name__)
-usage_logger = logging.getLogger("usage")
 subs_not_found = Counter("watcher_not_found", "Number of submissions which disappeared before processing")
 subs_cloudflare = Counter("watcher_cloudflare", "Number of submissions which returned cloudflare errors")
 subs_failed = Counter("watcher_failed", "Number of submissions which the sub watcher failed to get data for")
@@ -187,12 +186,11 @@ class SubscriptionWatcher:
             sub.latest_update = datetime.datetime.now()
             destination_map[sub.destination].append(sub)
         for dest, subs in destination_map.items():
-            sub_updates.inc()
             queries = ", ".join([f"\"{sub.query_str}\"" for sub in subs])
             prefix = f"Update on {queries} subscription{'' if len(subs) == 1 else 's'}:"
             try:
                 logger.info("Sending submission %s to subscription", result.submission_id)
-                usage_logger.info("Submission sent to subscription")
+                sub_updates.inc()
                 sendable = SendableFASubmission(result)
                 await sendable.send_message(self.client, dest, prefix=prefix)
             except (UserIsBlockedError, InputUserDeactivatedError):

--- a/fa_search_bot/tests/sites/test_e621_handler.py
+++ b/fa_search_bot/tests/sites/test_e621_handler.py
@@ -119,7 +119,7 @@ async def test_send_submission(mock_client):
     assert mock_send.call_args.kwargs['edit'] is True
 
 
-async def test_is_valid_submission_id__int():
+def test_is_valid_submission_id__int():
     test_str = "654322"
     api = MockAsyncYippiClient([])
     handler = E621Handler(api)
@@ -127,7 +127,7 @@ async def test_is_valid_submission_id__int():
     assert handler.is_valid_submission_id(test_str)
 
 
-async def test_is_valid_submission_id__md5():
+def test_is_valid_submission_id__md5():
     test_str = "f00c4c885c530e82bba55dfc3b5734a4"
     api = MockAsyncYippiClient([])
     handler = E621Handler(api)
@@ -135,7 +135,7 @@ async def test_is_valid_submission_id__md5():
     assert handler.is_valid_submission_id(test_str)
 
 
-async def test_is_valid_submission_id__str():
+def test_is_valid_submission_id__str():
     test_str = "hello world"
     api = MockAsyncYippiClient([])
     handler = E621Handler(api)

--- a/fa_search_bot/tests/sites/test_fa_export_api.py
+++ b/fa_search_bot/tests/sites/test_fa_export_api.py
@@ -8,20 +8,20 @@ from fa_search_bot.tests.util.submission_builder import SubmissionBuilder
 
 
 def test_constructor():
-    api_url = "http://example.com/"
+    api_url = "https://example.com/"
 
     api = FAExportAPI(api_url, ignore_status=True)
 
-    assert api.base_url == "http://example.com"
+    assert api.base_url == "https://example.com"
 
 
 def test_api_request(requests_mock):
-    api_url = "http://example.com/"
+    api_url = "https://example.com/"
     path = "/resources/123"
     api = FAExportAPI(api_url, ignore_status=True)
     test_obj = {"key": "value"}
     requests_mock.get(
-        "http://example.com/resources/123",
+        "https://example.com/resources/123",
         json=test_obj
     )
 
@@ -31,11 +31,11 @@ def test_api_request(requests_mock):
 
 
 def test_api_request__detects_cloudflare(requests_mock):
-    api_url = "http://example.com/"
+    api_url = "https://example.com/"
     path = "/resources/123"
     api = FAExportAPI(api_url, ignore_status=True)
     requests_mock.get(
-        "http://example.com/resources/123",
+        "https://example.com/resources/123",
         status_code=503,
         json={
             "error": "Cannot access FA, https://www.furaffinity.net/ as cloudflare protection is up",
@@ -52,12 +52,12 @@ def test_api_request__detects_cloudflare(requests_mock):
 
 @pytest.mark.asyncio
 async def test_api_request_with_retry__does_not_retry_200(requests_mock):
-    api_url = "http://example.com/"
+    api_url = "https://example.com/"
     path = "/resources/200"
     api = FAExportAPI(api_url, ignore_status=True)
     test_obj = {"key": "value"}
     requests_mock.get(
-        "http://example.com/resources/200",
+        "https://example.com/resources/200",
         [
             {"json": test_obj, "status_code": 200},
             {"text": "500 Errorequests_mock. Something broke.", "status_code": 500},
@@ -76,11 +76,11 @@ async def test_api_request_with_retry__does_not_retry_200(requests_mock):
 
 @pytest.mark.asyncio
 async def test_api_request_with_retry__does_not_retry_400_error(requests_mock):
-    api_url = "http://example.com/"
+    api_url = "https://example.com/"
     path = "/resources/400"
     api = FAExportAPI(api_url, ignore_status=True)
     requests_mock.get(
-        "http://example.com/resources/400",
+        "https://example.com/resources/400",
         [
             {"text": "400 error, you messed up.", "status_code": 400},
             {"text": "500 Errorequests_mock. Something broke.", "status_code": 500},
@@ -99,12 +99,12 @@ async def test_api_request_with_retry__does_not_retry_400_error(requests_mock):
 
 @pytest.mark.asyncio
 async def test_api_request_with_retry__retries_500_error(requests_mock):
-    api_url = "http://example.com/"
+    api_url = "https://example.com/"
     path = "/resources/500"
     api = FAExportAPI(api_url, ignore_status=True)
     test_obj = {"key": "value"}
     requests_mock.get(
-        "http://example.com/resources/500",
+        "https://example.com/resources/500",
         [
             {"text": "500 Errorequests_mock. Something broke.", "status_code": 500},
             {"text": "500 Errorequests_mock. Something broke.", "status_code": 500},
@@ -125,9 +125,9 @@ async def test_api_request_with_retry__retries_500_error(requests_mock):
 @pytest.mark.asyncio
 async def test_get_full_submission(requests_mock):
     builder = SubmissionBuilder(thumb_size=300)
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/submission/{builder.submission_id}.json",
+        f"https://example.com/submission/{builder.submission_id}.json",
         json=builder.build_submission_json()
     )
 
@@ -144,9 +144,9 @@ async def test_get_full_submission(requests_mock):
 @pytest.mark.asyncio
 async def test_get_full_submission_fails(requests_mock):
     post_id = "45282"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/submission/{post_id}.json",
+        f"https://example.com/submission/{post_id}.json",
         status_code=404
     )
 
@@ -164,9 +164,9 @@ async def test_get_user_folder(requests_mock):
     builder1 = SubmissionBuilder(submission_id=post_id1)
     builder2 = SubmissionBuilder(submission_id=post_id2)
     username = "fender"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/user/{username}/gallery.json?page=1&full=1",
+        f"https://example.com/user/{username}/gallery.json?page=1&full=1",
         json=[
             builder1.build_search_json(),
             builder2.build_search_json()
@@ -190,9 +190,9 @@ async def test_get_user_folder(requests_mock):
 async def test_get_user_folder_scraps(requests_mock):
     builder = SubmissionBuilder()
     username = "citrinelle"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/user/{username}/scraps.json?page=1&full=1",
+        f"https://example.com/user/{username}/scraps.json?page=1&full=1",
         json=[
             builder.build_search_json()
         ]
@@ -212,9 +212,9 @@ async def test_get_user_folder_awkward_characters(requests_mock):
     builder = SubmissionBuilder()
     username = "l[i]s"
     safe_username = "l%5Bi%5Ds"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/user/{safe_username}/gallery.json?page=1&full=1",
+        f"https://example.com/user/{safe_username}/gallery.json?page=1&full=1",
         json=[
             builder.build_search_json()
         ]
@@ -233,9 +233,9 @@ async def test_get_user_folder_awkward_characters(requests_mock):
 async def test_get_user_folder_specified_page(requests_mock):
     builder = SubmissionBuilder()
     username = "citrinelle"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/user/{username}/gallery.json?page=2&full=1",
+        f"https://example.com/user/{username}/gallery.json?page=2&full=1",
         json=[
             builder.build_search_json()
         ]
@@ -253,9 +253,9 @@ async def test_get_user_folder_specified_page(requests_mock):
 @pytest.mark.asyncio
 async def test_get_user_folder_empty(requests_mock):
     username = "fender"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/user/{username}/gallery.json?page=1&full=1",
+        f"https://example.com/user/{username}/gallery.json?page=1&full=1",
         json=[]
     )
 
@@ -267,9 +267,9 @@ async def test_get_user_folder_empty(requests_mock):
 @pytest.mark.asyncio
 async def test_get_user_folder_does_not_exist(requests_mock):
     username = "dont-real"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/user/{username}/gallery.json?page=1&full=1",
+        f"https://example.com/user/{username}/gallery.json?page=1&full=1",
         status_code=404
     )
 
@@ -283,9 +283,9 @@ async def test_get_user_folder_does_not_exist(requests_mock):
 @pytest.mark.asyncio
 async def test_get_user_folder_blank_username(requests_mock):
     username = ""
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/user/{username}/gallery.json?page=1&full=1",
+        f"https://example.com/user/{username}/gallery.json?page=1&full=1",
         json={
             "id": None,
             "name": "gallery",
@@ -307,9 +307,9 @@ async def test_get_search_results(requests_mock):
     builder1 = SubmissionBuilder(submission_id=post_id1)
     builder2 = SubmissionBuilder(submission_id=post_id2)
     search = "deer"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/search.json?full=1&perpage=48&q={search}&page=1",
+        f"https://example.com/search.json?full=1&perpage=48&q={search}&page=1",
         json=[
             builder1.build_search_json(),
             builder2.build_search_json()
@@ -334,9 +334,9 @@ async def test_get_search_results_with_space(requests_mock):
     builder = SubmissionBuilder()
     search = "deer lion"
     search_safe = "deer%20lion"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/search.json?full=1&perpage=48&q={search_safe}&page=1",
+        f"https://example.com/search.json?full=1&perpage=48&q={search_safe}&page=1",
         json=[
             builder.build_search_json()
         ]
@@ -354,9 +354,9 @@ async def test_get_search_results_with_extended_modifiers(requests_mock):
     builder = SubmissionBuilder()
     search = "(deer & !lion) | (goat & !tiger)"
     search_safe = "(deer%20&%20!lion)%20%7C%20(goat%20&%20!tiger)"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/search.json?full=1&perpage=48&q={search_safe}&page=1",
+        f"https://example.com/search.json?full=1&perpage=48&q={search_safe}&page=1",
         json=[
             builder.build_search_json()
         ]
@@ -373,9 +373,9 @@ async def test_get_search_results_with_extended_modifiers(requests_mock):
 async def test_get_search_results_specified_page(requests_mock):
     builder = SubmissionBuilder()
     search = "deer"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/search.json?full=1&perpage=48&q={search}&page=2",
+        f"https://example.com/search.json?full=1&perpage=48&q={search}&page=2",
         json=[
             builder.build_search_json()
         ]
@@ -391,9 +391,9 @@ async def test_get_search_results_specified_page(requests_mock):
 @pytest.mark.asyncio
 async def test_get_search_results_no_results(requests_mock):
     search = "chital_deer"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/search.json?full=1&perpage=48&q={search}&page=1",
+        f"https://example.com/search.json?full=1&perpage=48&q={search}&page=1",
         json=[
         ]
     )
@@ -406,9 +406,9 @@ async def test_get_search_results_no_results(requests_mock):
 @pytest.mark.asyncio
 async def test_get_browse_page_default_1(requests_mock):
     builder = SubmissionBuilder()
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/browse.json?page=1",
+        f"https://example.com/browse.json?page=1",
         json=[
             builder.build_search_json()
         ]
@@ -424,9 +424,9 @@ async def test_get_browse_page_default_1(requests_mock):
 @pytest.mark.asyncio
 async def test_get_browse_page_specify_page(requests_mock):
     builder = SubmissionBuilder()
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/browse.json?page=5",
+        f"https://example.com/browse.json?page=5",
         json=[
             builder.build_search_json()
         ]
@@ -442,9 +442,9 @@ async def test_get_browse_page_specify_page(requests_mock):
 @pytest.mark.asyncio
 async def test_get_browse_page_no_results(requests_mock):
     post_id = "32342"
-    api = FAExportAPI("http://example.com/", ignore_status=True)
+    api = FAExportAPI("https://example.com/", ignore_status=True)
     requests_mock.get(
-        f"http://example.com/browse.json?page=5",
+        f"https://example.com/browse.json?page=5",
         json=[
         ]
     )
@@ -457,9 +457,9 @@ async def test_get_browse_page_no_results(requests_mock):
 @pytest.mark.asyncio
 async def test_get_status_before_submission(requests_mock):
     builder = SubmissionBuilder(thumb_size=300)
-    api = FAExportAPI("http://example.com/")
+    api = FAExportAPI("https://example.com/")
     requests_mock.get(
-        "http://example.com/status.json",
+        "https://example.com/status.json",
         json={
             "online": {
                 "guests": 17,
@@ -471,7 +471,7 @@ async def test_get_status_before_submission(requests_mock):
         }
     )
     requests_mock.get(
-        f"http://example.com/submission/{builder.submission_id}.json",
+        f"https://example.com/submission/{builder.submission_id}.json",
         json=builder.build_submission_json()
     )
 
@@ -489,12 +489,12 @@ async def test_get_status_before_submission(requests_mock):
 
 @pytest.mark.asyncio
 async def test_get_status_api_retry(requests_mock):
-    api_url = "http://example.com/"
+    api_url = "https://example.com/"
     path = "/resources/200"
     api = FAExportAPI(api_url)
     test_obj = {"key": "value"}
     requests_mock.get(
-        "http://example.com/status.json",
+        "https://example.com/status.json",
         json={
             "online": {
                 "guests": 17,
@@ -506,7 +506,7 @@ async def test_get_status_api_retry(requests_mock):
         }
     )
     requests_mock.get(
-        "http://example.com/resources/200",
+        "https://example.com/resources/200",
         [
             {"json": test_obj, "status_code": 200},
         ]
@@ -522,12 +522,12 @@ async def test_get_status_api_retry(requests_mock):
 
 @pytest.mark.asyncio
 async def test_get_status_turns_on_slowdown(requests_mock):
-    api_url = "http://example.com/"
+    api_url = "https://example.com/"
     path = "/resources/200"
     api = FAExportAPI(api_url)
     test_obj = {"key": "value"}
     requests_mock.get(
-        "http://example.com/status.json",
+        "https://example.com/status.json",
         json={
             "online": {
                 "guests": 17,
@@ -539,7 +539,7 @@ async def test_get_status_turns_on_slowdown(requests_mock):
         }
     )
     requests_mock.get(
-        "http://example.com/resources/200",
+        "https://example.com/resources/200",
         [
             {"json": test_obj, "status_code": 200},
         ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -107,7 +107,7 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
-pywin32 = { version = "227", markers = "sys_platform == \"win32\"" }
+pywin32 = {version = "227", markers = "sys_platform == \"win32\""}
 requests = ">=2.14.2,<2.18.0 || >2.18.0"
 six = ">=1.4.0"
 websocket-client = ">=0.32.0"
@@ -232,6 +232,17 @@ python-versions = "*"
 six = ">=1.5.2"
 
 [[package]]
+name = "prometheus-client"
+version = "0.11.0"
+description = "Python client for the Prometheus monitoring system."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
 name = "psutil"
 version = "5.7.3"
 description = "Cross-platform lib for process and system monitoring in Python."
@@ -283,8 +294,8 @@ optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-jinja2 = { version = "*", optional = true, markers = "extra == \"diagrams\"" }
-railroad-diagrams = { version = "*", optional = true, markers = "extra == \"diagrams\"" }
+jinja2 = {version = "*", optional = true, markers = "extra == \"diagrams\""}
+railroad-diagrams = {version = "*", optional = true, markers = "extra == \"diagrams\""}
 
 [package.extras]
 diagrams = ["railroad-diagrams", "jinja2"]
@@ -473,7 +484,7 @@ python-versions = ">=3.6"
 [package.dependencies]
 alabaster = ">=0.7,<0.8"
 babel = ">=1.3"
-colorama = { version = ">=0.3.5", markers = "sys_platform == \"win32\"" }
+colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
 docutils = ">=0.14,<0.18"
 imagesize = "*"
 Jinja2 = ">=2.3"
@@ -487,7 +498,7 @@ sphinxcontrib-htmlhelp = "*"
 sphinxcontrib-jsmath = "*"
 sphinxcontrib-qthelp = "*"
 sphinxcontrib-serializinghtml = "*"
-sphinxcontrib-websupport = { version = "*", optional = true, markers = "extra == \"docs\"" }
+sphinxcontrib-websupport = {version = "*", optional = true, markers = "extra == \"docs\""}
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
@@ -726,81 +737,81 @@ python-versions = ">=3.7,<4.0"
 aiohttp = ">=3.6.2,<4.0.0"
 pyrate-limiter = ">=2.3.4,<3.0.0"
 requests = ">=2.23.0,<3.0.0"
-Sphinx = { version = ">=4.0.2,<5.0.0", extras = ["docs"] }
-sphinx-rtd-theme = { version = ">=0.5.2,<0.6.0", extras = ["docs"] }
-sphinxcontrib-napoleon = { version = ">=0.7,<0.8", extras = ["docs"] }
+Sphinx = {version = ">=4.0.2,<5.0.0", extras = ["docs"]}
+sphinx-rtd-theme = {version = ">=0.5.2,<0.6.0", extras = ["docs"]}
+sphinxcontrib-napoleon = {version = ">=0.7,<0.8", extras = ["docs"]}
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "6ad163626dc166d7c0f08d15f9297cbe21af596f16e4c06aff8c841b8f75572f"
+content-hash = "00fbec1bdafe5b7f1398c2678533084ed157ac5ce411b928d56bca1fdceed08f"
 
 [metadata.files]
 aiohttp = [
-    { file = "aiohttp-3.7.4.post0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:3cf75f7cdc2397ed4442594b935a11ed5569961333d49b7539ea741be2cc79d5" },
-    { file = "aiohttp-3.7.4.post0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:4b302b45040890cea949ad092479e01ba25911a15e648429c7c5aae9650c67a8" },
-    { file = "aiohttp-3.7.4.post0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:fe60131d21b31fd1a14bd43e6bb88256f69dfc3188b3a89d736d6c71ed43ec95" },
-    { file = "aiohttp-3.7.4.post0-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:393f389841e8f2dfc86f774ad22f00923fdee66d238af89b70ea314c4aefd290" },
-    { file = "aiohttp-3.7.4.post0-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:c6e9dcb4cb338d91a73f178d866d051efe7c62a7166653a91e7d9fb18274058f" },
-    { file = "aiohttp-3.7.4.post0-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:5df68496d19f849921f05f14f31bd6ef53ad4b00245da3195048c69934521809" },
-    { file = "aiohttp-3.7.4.post0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:0563c1b3826945eecd62186f3f5c7d31abb7391fedc893b7e2b26303b5a9f3fe" },
-    { file = "aiohttp-3.7.4.post0-cp36-cp36m-win32.whl", hash = "sha256:3d78619672183be860b96ed96f533046ec97ca067fd46ac1f6a09cd9b7484287" },
-    { file = "aiohttp-3.7.4.post0-cp36-cp36m-win_amd64.whl", hash = "sha256:f705e12750171c0ab4ef2a3c76b9a4024a62c4103e3a55dd6f99265b9bc6fcfc" },
-    { file = "aiohttp-3.7.4.post0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:230a8f7e24298dea47659251abc0fd8b3c4e38a664c59d4b89cca7f6c09c9e87" },
-    { file = "aiohttp-3.7.4.post0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2e19413bf84934d651344783c9f5e22dee452e251cfd220ebadbed2d9931dbf0" },
-    { file = "aiohttp-3.7.4.post0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:e4b2b334e68b18ac9817d828ba44d8fcb391f6acb398bcc5062b14b2cbeac970" },
-    { file = "aiohttp-3.7.4.post0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:d012ad7911653a906425d8473a1465caa9f8dea7fcf07b6d870397b774ea7c0f" },
-    { file = "aiohttp-3.7.4.post0-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:40eced07f07a9e60e825554a31f923e8d3997cfc7fb31dbc1328c70826e04cde" },
-    { file = "aiohttp-3.7.4.post0-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:209b4a8ee987eccc91e2bd3ac36adee0e53a5970b8ac52c273f7f8fd4872c94c" },
-    { file = "aiohttp-3.7.4.post0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:14762875b22d0055f05d12abc7f7d61d5fd4fe4642ce1a249abdf8c700bf1fd8" },
-    { file = "aiohttp-3.7.4.post0-cp37-cp37m-win32.whl", hash = "sha256:7615dab56bb07bff74bc865307aeb89a8bfd9941d2ef9d817b9436da3a0ea54f" },
-    { file = "aiohttp-3.7.4.post0-cp37-cp37m-win_amd64.whl", hash = "sha256:d9e13b33afd39ddeb377eff2c1c4f00544e191e1d1dee5b6c51ddee8ea6f0cf5" },
-    { file = "aiohttp-3.7.4.post0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:547da6cacac20666422d4882cfcd51298d45f7ccb60a04ec27424d2f36ba3eaf" },
-    { file = "aiohttp-3.7.4.post0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:af9aa9ef5ba1fd5b8c948bb11f44891968ab30356d65fd0cc6707d989cd521df" },
-    { file = "aiohttp-3.7.4.post0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:64322071e046020e8797117b3658b9c2f80e3267daec409b350b6a7a05041213" },
-    { file = "aiohttp-3.7.4.post0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:bb437315738aa441251214dad17428cafda9cdc9729499f1d6001748e1d432f4" },
-    { file = "aiohttp-3.7.4.post0-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:e54962802d4b8b18b6207d4a927032826af39395a3bd9196a5af43fc4e60b009" },
-    { file = "aiohttp-3.7.4.post0-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:a00bb73540af068ca7390e636c01cbc4f644961896fa9363154ff43fd37af2f5" },
-    { file = "aiohttp-3.7.4.post0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:79ebfc238612123a713a457d92afb4096e2148be17df6c50fb9bf7a81c2f8013" },
-    { file = "aiohttp-3.7.4.post0-cp38-cp38-win32.whl", hash = "sha256:515dfef7f869a0feb2afee66b957cc7bbe9ad0cdee45aec7fdc623f4ecd4fb16" },
-    { file = "aiohttp-3.7.4.post0-cp38-cp38-win_amd64.whl", hash = "sha256:114b281e4d68302a324dd33abb04778e8557d88947875cbf4e842c2c01a030c5" },
-    { file = "aiohttp-3.7.4.post0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:7b18b97cf8ee5452fa5f4e3af95d01d84d86d32c5e2bfa260cf041749d66360b" },
-    { file = "aiohttp-3.7.4.post0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:15492a6368d985b76a2a5fdd2166cddfea5d24e69eefed4630cbaae5c81d89bd" },
-    { file = "aiohttp-3.7.4.post0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:bdb230b4943891321e06fc7def63c7aace16095be7d9cf3b1e01be2f10fba439" },
-    { file = "aiohttp-3.7.4.post0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:cffe3ab27871bc3ea47df5d8f7013945712c46a3cc5a95b6bee15887f1675c22" },
-    { file = "aiohttp-3.7.4.post0-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:f881853d2643a29e643609da57b96d5f9c9b93f62429dcc1cbb413c7d07f0e1a" },
-    { file = "aiohttp-3.7.4.post0-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:a5ca29ee66f8343ed336816c553e82d6cade48a3ad702b9ffa6125d187e2dedb" },
-    { file = "aiohttp-3.7.4.post0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:17c073de315745a1510393a96e680d20af8e67e324f70b42accbd4cb3315c9fb" },
-    { file = "aiohttp-3.7.4.post0-cp39-cp39-win32.whl", hash = "sha256:932bb1ea39a54e9ea27fc9232163059a0b8855256f4052e776357ad9add6f1c9" },
-    { file = "aiohttp-3.7.4.post0-cp39-cp39-win_amd64.whl", hash = "sha256:02f46fc0e3c5ac58b80d4d56eb0a7c7d97fcef69ace9326289fb9f1955e65cfe" },
-    { file = "aiohttp-3.7.4.post0.tar.gz", hash = "sha256:493d3299ebe5f5a7c66b9819eacdcfbbaaf1a8e84911ddffcdc48888497afecf" },
+    {file = "aiohttp-3.7.4.post0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:3cf75f7cdc2397ed4442594b935a11ed5569961333d49b7539ea741be2cc79d5"},
+    {file = "aiohttp-3.7.4.post0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:4b302b45040890cea949ad092479e01ba25911a15e648429c7c5aae9650c67a8"},
+    {file = "aiohttp-3.7.4.post0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:fe60131d21b31fd1a14bd43e6bb88256f69dfc3188b3a89d736d6c71ed43ec95"},
+    {file = "aiohttp-3.7.4.post0-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:393f389841e8f2dfc86f774ad22f00923fdee66d238af89b70ea314c4aefd290"},
+    {file = "aiohttp-3.7.4.post0-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:c6e9dcb4cb338d91a73f178d866d051efe7c62a7166653a91e7d9fb18274058f"},
+    {file = "aiohttp-3.7.4.post0-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:5df68496d19f849921f05f14f31bd6ef53ad4b00245da3195048c69934521809"},
+    {file = "aiohttp-3.7.4.post0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:0563c1b3826945eecd62186f3f5c7d31abb7391fedc893b7e2b26303b5a9f3fe"},
+    {file = "aiohttp-3.7.4.post0-cp36-cp36m-win32.whl", hash = "sha256:3d78619672183be860b96ed96f533046ec97ca067fd46ac1f6a09cd9b7484287"},
+    {file = "aiohttp-3.7.4.post0-cp36-cp36m-win_amd64.whl", hash = "sha256:f705e12750171c0ab4ef2a3c76b9a4024a62c4103e3a55dd6f99265b9bc6fcfc"},
+    {file = "aiohttp-3.7.4.post0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:230a8f7e24298dea47659251abc0fd8b3c4e38a664c59d4b89cca7f6c09c9e87"},
+    {file = "aiohttp-3.7.4.post0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2e19413bf84934d651344783c9f5e22dee452e251cfd220ebadbed2d9931dbf0"},
+    {file = "aiohttp-3.7.4.post0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:e4b2b334e68b18ac9817d828ba44d8fcb391f6acb398bcc5062b14b2cbeac970"},
+    {file = "aiohttp-3.7.4.post0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:d012ad7911653a906425d8473a1465caa9f8dea7fcf07b6d870397b774ea7c0f"},
+    {file = "aiohttp-3.7.4.post0-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:40eced07f07a9e60e825554a31f923e8d3997cfc7fb31dbc1328c70826e04cde"},
+    {file = "aiohttp-3.7.4.post0-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:209b4a8ee987eccc91e2bd3ac36adee0e53a5970b8ac52c273f7f8fd4872c94c"},
+    {file = "aiohttp-3.7.4.post0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:14762875b22d0055f05d12abc7f7d61d5fd4fe4642ce1a249abdf8c700bf1fd8"},
+    {file = "aiohttp-3.7.4.post0-cp37-cp37m-win32.whl", hash = "sha256:7615dab56bb07bff74bc865307aeb89a8bfd9941d2ef9d817b9436da3a0ea54f"},
+    {file = "aiohttp-3.7.4.post0-cp37-cp37m-win_amd64.whl", hash = "sha256:d9e13b33afd39ddeb377eff2c1c4f00544e191e1d1dee5b6c51ddee8ea6f0cf5"},
+    {file = "aiohttp-3.7.4.post0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:547da6cacac20666422d4882cfcd51298d45f7ccb60a04ec27424d2f36ba3eaf"},
+    {file = "aiohttp-3.7.4.post0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:af9aa9ef5ba1fd5b8c948bb11f44891968ab30356d65fd0cc6707d989cd521df"},
+    {file = "aiohttp-3.7.4.post0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:64322071e046020e8797117b3658b9c2f80e3267daec409b350b6a7a05041213"},
+    {file = "aiohttp-3.7.4.post0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:bb437315738aa441251214dad17428cafda9cdc9729499f1d6001748e1d432f4"},
+    {file = "aiohttp-3.7.4.post0-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:e54962802d4b8b18b6207d4a927032826af39395a3bd9196a5af43fc4e60b009"},
+    {file = "aiohttp-3.7.4.post0-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:a00bb73540af068ca7390e636c01cbc4f644961896fa9363154ff43fd37af2f5"},
+    {file = "aiohttp-3.7.4.post0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:79ebfc238612123a713a457d92afb4096e2148be17df6c50fb9bf7a81c2f8013"},
+    {file = "aiohttp-3.7.4.post0-cp38-cp38-win32.whl", hash = "sha256:515dfef7f869a0feb2afee66b957cc7bbe9ad0cdee45aec7fdc623f4ecd4fb16"},
+    {file = "aiohttp-3.7.4.post0-cp38-cp38-win_amd64.whl", hash = "sha256:114b281e4d68302a324dd33abb04778e8557d88947875cbf4e842c2c01a030c5"},
+    {file = "aiohttp-3.7.4.post0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:7b18b97cf8ee5452fa5f4e3af95d01d84d86d32c5e2bfa260cf041749d66360b"},
+    {file = "aiohttp-3.7.4.post0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:15492a6368d985b76a2a5fdd2166cddfea5d24e69eefed4630cbaae5c81d89bd"},
+    {file = "aiohttp-3.7.4.post0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:bdb230b4943891321e06fc7def63c7aace16095be7d9cf3b1e01be2f10fba439"},
+    {file = "aiohttp-3.7.4.post0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:cffe3ab27871bc3ea47df5d8f7013945712c46a3cc5a95b6bee15887f1675c22"},
+    {file = "aiohttp-3.7.4.post0-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:f881853d2643a29e643609da57b96d5f9c9b93f62429dcc1cbb413c7d07f0e1a"},
+    {file = "aiohttp-3.7.4.post0-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:a5ca29ee66f8343ed336816c553e82d6cade48a3ad702b9ffa6125d187e2dedb"},
+    {file = "aiohttp-3.7.4.post0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:17c073de315745a1510393a96e680d20af8e67e324f70b42accbd4cb3315c9fb"},
+    {file = "aiohttp-3.7.4.post0-cp39-cp39-win32.whl", hash = "sha256:932bb1ea39a54e9ea27fc9232163059a0b8855256f4052e776357ad9add6f1c9"},
+    {file = "aiohttp-3.7.4.post0-cp39-cp39-win_amd64.whl", hash = "sha256:02f46fc0e3c5ac58b80d4d56eb0a7c7d97fcef69ace9326289fb9f1955e65cfe"},
+    {file = "aiohttp-3.7.4.post0.tar.gz", hash = "sha256:493d3299ebe5f5a7c66b9819eacdcfbbaaf1a8e84911ddffcdc48888497afecf"},
 ]
 alabaster = [
-    { file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359" },
-    { file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02" },
+    {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
+    {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
 ]
 async-lru = [
-    { file = "async_lru-1.0.2.tar.gz", hash = "sha256:baa898027619f5cc31b7966f96f00e4fc0df43ba206a8940a5d1af5336a477cb" },
+    {file = "async_lru-1.0.2.tar.gz", hash = "sha256:baa898027619f5cc31b7966f96f00e4fc0df43ba206a8940a5d1af5336a477cb"},
 ]
 async-timeout = [
-    { file = "async-timeout-3.0.1.tar.gz", hash = "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f" },
-    { file = "async_timeout-3.0.1-py3-none-any.whl", hash = "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3" },
+    {file = "async-timeout-3.0.1.tar.gz", hash = "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f"},
+    {file = "async_timeout-3.0.1-py3-none-any.whl", hash = "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"},
 ]
 atomicwrites = [
-    { file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197" },
-    { file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a" },
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    { file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc" },
-    { file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594" },
+    {file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"},
+    {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},
 ]
 babel = [
-    { file = "Babel-2.9.1-py2.py3-none-any.whl", hash = "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9" },
-    { file = "Babel-2.9.1.tar.gz", hash = "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0" },
+    {file = "Babel-2.9.1-py2.py3-none-any.whl", hash = "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9"},
+    {file = "Babel-2.9.1.tar.gz", hash = "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"},
 ]
 certifi = [
-    { file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41" },
-    { file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3" },
+    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
+    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -811,24 +822,24 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 docker = [
-    { file = "docker-4.3.1-py2.py3-none-any.whl", hash = "sha256:13966471e8bc23b36bfb3a6fb4ab75043a5ef1dac86516274777576bed3b9828" },
-    { file = "docker-4.3.1.tar.gz", hash = "sha256:bad94b8dd001a8a4af19ce4becc17f41b09f228173ffe6a4e0355389eef142f2" },
+    {file = "docker-4.3.1-py2.py3-none-any.whl", hash = "sha256:13966471e8bc23b36bfb3a6fb4ab75043a5ef1dac86516274777576bed3b9828"},
+    {file = "docker-4.3.1.tar.gz", hash = "sha256:bad94b8dd001a8a4af19ce4becc17f41b09f228173ffe6a4e0355389eef142f2"},
 ]
 docutils = [
-    { file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af" },
-    { file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc" },
+    {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
+    {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
 idna = [
-    { file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0" },
-    { file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6" },
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 imagesize = [
-    { file = "imagesize-1.2.0-py2.py3-none-any.whl", hash = "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1" },
-    { file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1" },
+    {file = "imagesize-1.2.0-py2.py3-none-any.whl", hash = "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1"},
+    {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 isodate = [
-    { file = "isodate-0.6.0-py2.py3-none-any.whl", hash = "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81" },
-    { file = "isodate-0.6.0.tar.gz", hash = "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8" },
+    {file = "isodate-0.6.0-py2.py3-none-any.whl", hash = "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"},
+    {file = "isodate-0.6.0.tar.gz", hash = "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8"},
 ]
 jinja2 = [
     {file = "Jinja2-2.11.2-py2.py3-none-any.whl", hash = "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"},
@@ -870,106 +881,110 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 more-itertools = [
-    { file = "more-itertools-8.6.0.tar.gz", hash = "sha256:b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf" },
-    { file = "more_itertools-8.6.0-py3-none-any.whl", hash = "sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330" },
+    {file = "more-itertools-8.6.0.tar.gz", hash = "sha256:b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf"},
+    {file = "more_itertools-8.6.0-py3-none-any.whl", hash = "sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330"},
 ]
 multidict = [
-    { file = "multidict-5.1.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:b7993704f1a4b204e71debe6095150d43b2ee6150fa4f44d6d966ec356a8d61f" },
-    { file = "multidict-5.1.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9dd6e9b1a913d096ac95d0399bd737e00f2af1e1594a787e00f7975778c8b2bf" },
-    { file = "multidict-5.1.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f21756997ad8ef815d8ef3d34edd98804ab5ea337feedcd62fb52d22bf531281" },
-    { file = "multidict-5.1.0-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:1ab820665e67373de5802acae069a6a05567ae234ddb129f31d290fc3d1aa56d" },
-    { file = "multidict-5.1.0-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:9436dc58c123f07b230383083855593550c4d301d2532045a17ccf6eca505f6d" },
-    { file = "multidict-5.1.0-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:830f57206cc96ed0ccf68304141fec9481a096c4d2e2831f311bde1c404401da" },
-    { file = "multidict-5.1.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:2e68965192c4ea61fff1b81c14ff712fc7dc15d2bd120602e4a3494ea6584224" },
-    { file = "multidict-5.1.0-cp36-cp36m-win32.whl", hash = "sha256:2f1a132f1c88724674271d636e6b7351477c27722f2ed789f719f9e3545a3d26" },
-    { file = "multidict-5.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:3a4f32116f8f72ecf2a29dabfb27b23ab7cdc0ba807e8459e59a93a9be9506f6" },
-    { file = "multidict-5.1.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:46c73e09ad374a6d876c599f2328161bcd95e280f84d2060cf57991dec5cfe76" },
-    { file = "multidict-5.1.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:018132dbd8688c7a69ad89c4a3f39ea2f9f33302ebe567a879da8f4ca73f0d0a" },
-    { file = "multidict-5.1.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:4b186eb7d6ae7c06eb4392411189469e6a820da81447f46c0072a41c748ab73f" },
-    { file = "multidict-5.1.0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:3a041b76d13706b7fff23b9fc83117c7b8fe8d5fe9e6be45eee72b9baa75f348" },
-    { file = "multidict-5.1.0-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:051012ccee979b2b06be928a6150d237aec75dd6bf2d1eeeb190baf2b05abc93" },
-    { file = "multidict-5.1.0-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:6a4d5ce640e37b0efcc8441caeea8f43a06addace2335bd11151bc02d2ee31f9" },
-    { file = "multidict-5.1.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:5cf3443199b83ed9e955f511b5b241fd3ae004e3cb81c58ec10f4fe47c7dce37" },
-    { file = "multidict-5.1.0-cp37-cp37m-win32.whl", hash = "sha256:f200755768dc19c6f4e2b672421e0ebb3dd54c38d5a4f262b872d8cfcc9e93b5" },
-    { file = "multidict-5.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:05c20b68e512166fddba59a918773ba002fdd77800cad9f55b59790030bab632" },
-    { file = "multidict-5.1.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:54fd1e83a184e19c598d5e70ba508196fd0bbdd676ce159feb412a4a6664f952" },
-    { file = "multidict-5.1.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0e3c84e6c67eba89c2dbcee08504ba8644ab4284863452450520dad8f1e89b79" },
-    { file = "multidict-5.1.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:dc862056f76443a0db4509116c5cd480fe1b6a2d45512a653f9a855cc0517456" },
-    { file = "multidict-5.1.0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:0e929169f9c090dae0646a011c8b058e5e5fb391466016b39d21745b48817fd7" },
-    { file = "multidict-5.1.0-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:d81eddcb12d608cc08081fa88d046c78afb1bf8107e6feab5d43503fea74a635" },
-    { file = "multidict-5.1.0-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:585fd452dd7782130d112f7ddf3473ffdd521414674c33876187e101b588738a" },
-    { file = "multidict-5.1.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:37e5438e1c78931df5d3c0c78ae049092877e5e9c02dd1ff5abb9cf27a5914ea" },
-    { file = "multidict-5.1.0-cp38-cp38-win32.whl", hash = "sha256:07b42215124aedecc6083f1ce6b7e5ec5b50047afa701f3442054373a6deb656" },
-    { file = "multidict-5.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:929006d3c2d923788ba153ad0de8ed2e5ed39fdbe8e7be21e2f22ed06c6783d3" },
-    { file = "multidict-5.1.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b797515be8743b771aa868f83563f789bbd4b236659ba52243b735d80b29ed93" },
-    { file = "multidict-5.1.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d5c65bdf4484872c4af3150aeebe101ba560dcfb34488d9a8ff8dbcd21079647" },
-    { file = "multidict-5.1.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b47a43177a5e65b771b80db71e7be76c0ba23cc8aa73eeeb089ed5219cdbe27d" },
-    { file = "multidict-5.1.0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:806068d4f86cb06af37cd65821554f98240a19ce646d3cd24e1c33587f313eb8" },
-    { file = "multidict-5.1.0-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:46dd362c2f045095c920162e9307de5ffd0a1bfbba0a6e990b344366f55a30c1" },
-    { file = "multidict-5.1.0-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:ace010325c787c378afd7f7c1ac66b26313b3344628652eacd149bdd23c68841" },
-    { file = "multidict-5.1.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:ecc771ab628ea281517e24fd2c52e8f31c41e66652d07599ad8818abaad38cda" },
-    { file = "multidict-5.1.0-cp39-cp39-win32.whl", hash = "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80" },
-    { file = "multidict-5.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7df80d07818b385f3129180369079bd6934cf70469f99daaebfac89dca288359" },
-    { file = "multidict-5.1.0.tar.gz", hash = "sha256:25b4e5f22d3a37ddf3effc0710ba692cfc792c2b9edfb9c05aefe823256e84d5" },
+    {file = "multidict-5.1.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:b7993704f1a4b204e71debe6095150d43b2ee6150fa4f44d6d966ec356a8d61f"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9dd6e9b1a913d096ac95d0399bd737e00f2af1e1594a787e00f7975778c8b2bf"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f21756997ad8ef815d8ef3d34edd98804ab5ea337feedcd62fb52d22bf531281"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:1ab820665e67373de5802acae069a6a05567ae234ddb129f31d290fc3d1aa56d"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:9436dc58c123f07b230383083855593550c4d301d2532045a17ccf6eca505f6d"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:830f57206cc96ed0ccf68304141fec9481a096c4d2e2831f311bde1c404401da"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:2e68965192c4ea61fff1b81c14ff712fc7dc15d2bd120602e4a3494ea6584224"},
+    {file = "multidict-5.1.0-cp36-cp36m-win32.whl", hash = "sha256:2f1a132f1c88724674271d636e6b7351477c27722f2ed789f719f9e3545a3d26"},
+    {file = "multidict-5.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:3a4f32116f8f72ecf2a29dabfb27b23ab7cdc0ba807e8459e59a93a9be9506f6"},
+    {file = "multidict-5.1.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:46c73e09ad374a6d876c599f2328161bcd95e280f84d2060cf57991dec5cfe76"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:018132dbd8688c7a69ad89c4a3f39ea2f9f33302ebe567a879da8f4ca73f0d0a"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:4b186eb7d6ae7c06eb4392411189469e6a820da81447f46c0072a41c748ab73f"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:3a041b76d13706b7fff23b9fc83117c7b8fe8d5fe9e6be45eee72b9baa75f348"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:051012ccee979b2b06be928a6150d237aec75dd6bf2d1eeeb190baf2b05abc93"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:6a4d5ce640e37b0efcc8441caeea8f43a06addace2335bd11151bc02d2ee31f9"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:5cf3443199b83ed9e955f511b5b241fd3ae004e3cb81c58ec10f4fe47c7dce37"},
+    {file = "multidict-5.1.0-cp37-cp37m-win32.whl", hash = "sha256:f200755768dc19c6f4e2b672421e0ebb3dd54c38d5a4f262b872d8cfcc9e93b5"},
+    {file = "multidict-5.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:05c20b68e512166fddba59a918773ba002fdd77800cad9f55b59790030bab632"},
+    {file = "multidict-5.1.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:54fd1e83a184e19c598d5e70ba508196fd0bbdd676ce159feb412a4a6664f952"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0e3c84e6c67eba89c2dbcee08504ba8644ab4284863452450520dad8f1e89b79"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:dc862056f76443a0db4509116c5cd480fe1b6a2d45512a653f9a855cc0517456"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:0e929169f9c090dae0646a011c8b058e5e5fb391466016b39d21745b48817fd7"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:d81eddcb12d608cc08081fa88d046c78afb1bf8107e6feab5d43503fea74a635"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:585fd452dd7782130d112f7ddf3473ffdd521414674c33876187e101b588738a"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:37e5438e1c78931df5d3c0c78ae049092877e5e9c02dd1ff5abb9cf27a5914ea"},
+    {file = "multidict-5.1.0-cp38-cp38-win32.whl", hash = "sha256:07b42215124aedecc6083f1ce6b7e5ec5b50047afa701f3442054373a6deb656"},
+    {file = "multidict-5.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:929006d3c2d923788ba153ad0de8ed2e5ed39fdbe8e7be21e2f22ed06c6783d3"},
+    {file = "multidict-5.1.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b797515be8743b771aa868f83563f789bbd4b236659ba52243b735d80b29ed93"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d5c65bdf4484872c4af3150aeebe101ba560dcfb34488d9a8ff8dbcd21079647"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b47a43177a5e65b771b80db71e7be76c0ba23cc8aa73eeeb089ed5219cdbe27d"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:806068d4f86cb06af37cd65821554f98240a19ce646d3cd24e1c33587f313eb8"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:46dd362c2f045095c920162e9307de5ffd0a1bfbba0a6e990b344366f55a30c1"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:ace010325c787c378afd7f7c1ac66b26313b3344628652eacd149bdd23c68841"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:ecc771ab628ea281517e24fd2c52e8f31c41e66652d07599ad8818abaad38cda"},
+    {file = "multidict-5.1.0-cp39-cp39-win32.whl", hash = "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80"},
+    {file = "multidict-5.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7df80d07818b385f3129180369079bd6934cf70469f99daaebfac89dca288359"},
+    {file = "multidict-5.1.0.tar.gz", hash = "sha256:25b4e5f22d3a37ddf3effc0710ba692cfc792c2b9edfb9c05aefe823256e84d5"},
 ]
 packaging = [
-    { file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181" },
-    { file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8" },
+    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
+    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
 ]
 pillow = [
-    { file = "Pillow-8.2.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9" },
-    { file = "Pillow-8.2.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a013cbe25d20c2e0c4e85a9daf438f85121a4d0344ddc76e33fd7e3965d9af4b" },
-    { file = "Pillow-8.2.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b" },
-    { file = "Pillow-8.2.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9" },
-    { file = "Pillow-8.2.0-cp36-cp36m-win32.whl", hash = "sha256:12e5e7471f9b637762453da74e390e56cc43e486a88289995c1f4c1dc0bfe727" },
-    { file = "Pillow-8.2.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f" },
-    { file = "Pillow-8.2.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:cb7a09e173903541fa888ba010c345893cd9fc1b5891aaf060f6ca77b6a3722d" },
-    { file = "Pillow-8.2.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0d19d70ee7c2ba97631bae1e7d4725cdb2ecf238178096e8c82ee481e189168a" },
-    { file = "Pillow-8.2.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:083781abd261bdabf090ad07bb69f8f5599943ddb539d64497ed021b2a67e5a9" },
-    { file = "Pillow-8.2.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:c6b39294464b03457f9064e98c124e09008b35a62e3189d3513e5148611c9388" },
-    { file = "Pillow-8.2.0-cp37-cp37m-win32.whl", hash = "sha256:01425106e4e8cee195a411f729cff2a7d61813b0b11737c12bd5991f5f14bcd5" },
-    { file = "Pillow-8.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3b570f84a6161cf8865c4e08adf629441f56e32f180f7aa4ccbd2e0a5a02cba2" },
-    { file = "Pillow-8.2.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:031a6c88c77d08aab84fecc05c3cde8414cd6f8406f4d2b16fed1e97634cc8a4" },
-    { file = "Pillow-8.2.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:66cc56579fd91f517290ab02c51e3a80f581aba45fd924fcdee01fa06e635812" },
-    { file = "Pillow-8.2.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c32cc3145928c4305d142ebec682419a6c0a8ce9e33db900027ddca1ec39178" },
-    { file = "Pillow-8.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:624b977355cde8b065f6d51b98497d6cd5fbdd4f36405f7a8790e3376125e2bb" },
-    { file = "Pillow-8.2.0-cp38-cp38-win32.whl", hash = "sha256:5cbf3e3b1014dddc45496e8cf38b9f099c95a326275885199f427825c6522232" },
-    { file = "Pillow-8.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:463822e2f0d81459e113372a168f2ff59723e78528f91f0bd25680ac185cf797" },
-    { file = "Pillow-8.2.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:95d5ef984eff897850f3a83883363da64aae1000e79cb3c321915468e8c6add5" },
-    { file = "Pillow-8.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b91c36492a4bbb1ee855b7d16fe51379e5f96b85692dc8210831fbb24c43e484" },
-    { file = "Pillow-8.2.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d68cb92c408261f806b15923834203f024110a2e2872ecb0bd2a110f89d3c602" },
-    { file = "Pillow-8.2.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f217c3954ce5fd88303fc0c317af55d5e0204106d86dea17eb8205700d47dec2" },
-    { file = "Pillow-8.2.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5b70110acb39f3aff6b74cf09bb4169b167e2660dabc304c1e25b6555fa781ef" },
-    { file = "Pillow-8.2.0-cp39-cp39-win32.whl", hash = "sha256:a7d5e9fad90eff8f6f6106d3b98b553a88b6f976e51fce287192a5d2d5363713" },
-    { file = "Pillow-8.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:238c197fc275b475e87c1453b05b467d2d02c2915fdfdd4af126145ff2e4610c" },
-    { file = "Pillow-8.2.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:0e04d61f0064b545b989126197930807c86bcbd4534d39168f4aa5fda39bb8f9" },
-    { file = "Pillow-8.2.0-pp36-pypy36_pp73-manylinux2010_i686.whl", hash = "sha256:63728564c1410d99e6d1ae8e3b810fe012bc440952168af0a2877e8ff5ab96b9" },
-    { file = "Pillow-8.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:c03c07ed32c5324939b19e36ae5f75c660c81461e312a41aea30acdd46f93a7c" },
-    { file = "Pillow-8.2.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:4d98abdd6b1e3bf1a1cbb14c3895226816e666749ac040c4e2554231068c639b" },
-    { file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4" },
-    { file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120" },
-    { file = "Pillow-8.2.0-pp37-pypy37_pp73-win32.whl", hash = "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e" },
-    { file = "Pillow-8.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:8b56553c0345ad6dcb2e9b433ae47d67f95fc23fe28a0bde15a120f25257e291" },
-    { file = "Pillow-8.2.0.tar.gz", hash = "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1" },
+    {file = "Pillow-8.2.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9"},
+    {file = "Pillow-8.2.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a013cbe25d20c2e0c4e85a9daf438f85121a4d0344ddc76e33fd7e3965d9af4b"},
+    {file = "Pillow-8.2.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b"},
+    {file = "Pillow-8.2.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9"},
+    {file = "Pillow-8.2.0-cp36-cp36m-win32.whl", hash = "sha256:12e5e7471f9b637762453da74e390e56cc43e486a88289995c1f4c1dc0bfe727"},
+    {file = "Pillow-8.2.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f"},
+    {file = "Pillow-8.2.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:cb7a09e173903541fa888ba010c345893cd9fc1b5891aaf060f6ca77b6a3722d"},
+    {file = "Pillow-8.2.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0d19d70ee7c2ba97631bae1e7d4725cdb2ecf238178096e8c82ee481e189168a"},
+    {file = "Pillow-8.2.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:083781abd261bdabf090ad07bb69f8f5599943ddb539d64497ed021b2a67e5a9"},
+    {file = "Pillow-8.2.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:c6b39294464b03457f9064e98c124e09008b35a62e3189d3513e5148611c9388"},
+    {file = "Pillow-8.2.0-cp37-cp37m-win32.whl", hash = "sha256:01425106e4e8cee195a411f729cff2a7d61813b0b11737c12bd5991f5f14bcd5"},
+    {file = "Pillow-8.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3b570f84a6161cf8865c4e08adf629441f56e32f180f7aa4ccbd2e0a5a02cba2"},
+    {file = "Pillow-8.2.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:031a6c88c77d08aab84fecc05c3cde8414cd6f8406f4d2b16fed1e97634cc8a4"},
+    {file = "Pillow-8.2.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:66cc56579fd91f517290ab02c51e3a80f581aba45fd924fcdee01fa06e635812"},
+    {file = "Pillow-8.2.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c32cc3145928c4305d142ebec682419a6c0a8ce9e33db900027ddca1ec39178"},
+    {file = "Pillow-8.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:624b977355cde8b065f6d51b98497d6cd5fbdd4f36405f7a8790e3376125e2bb"},
+    {file = "Pillow-8.2.0-cp38-cp38-win32.whl", hash = "sha256:5cbf3e3b1014dddc45496e8cf38b9f099c95a326275885199f427825c6522232"},
+    {file = "Pillow-8.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:463822e2f0d81459e113372a168f2ff59723e78528f91f0bd25680ac185cf797"},
+    {file = "Pillow-8.2.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:95d5ef984eff897850f3a83883363da64aae1000e79cb3c321915468e8c6add5"},
+    {file = "Pillow-8.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b91c36492a4bbb1ee855b7d16fe51379e5f96b85692dc8210831fbb24c43e484"},
+    {file = "Pillow-8.2.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d68cb92c408261f806b15923834203f024110a2e2872ecb0bd2a110f89d3c602"},
+    {file = "Pillow-8.2.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f217c3954ce5fd88303fc0c317af55d5e0204106d86dea17eb8205700d47dec2"},
+    {file = "Pillow-8.2.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5b70110acb39f3aff6b74cf09bb4169b167e2660dabc304c1e25b6555fa781ef"},
+    {file = "Pillow-8.2.0-cp39-cp39-win32.whl", hash = "sha256:a7d5e9fad90eff8f6f6106d3b98b553a88b6f976e51fce287192a5d2d5363713"},
+    {file = "Pillow-8.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:238c197fc275b475e87c1453b05b467d2d02c2915fdfdd4af126145ff2e4610c"},
+    {file = "Pillow-8.2.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:0e04d61f0064b545b989126197930807c86bcbd4534d39168f4aa5fda39bb8f9"},
+    {file = "Pillow-8.2.0-pp36-pypy36_pp73-manylinux2010_i686.whl", hash = "sha256:63728564c1410d99e6d1ae8e3b810fe012bc440952168af0a2877e8ff5ab96b9"},
+    {file = "Pillow-8.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:c03c07ed32c5324939b19e36ae5f75c660c81461e312a41aea30acdd46f93a7c"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:4d98abdd6b1e3bf1a1cbb14c3895226816e666749ac040c4e2554231068c639b"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-win32.whl", hash = "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:8b56553c0345ad6dcb2e9b433ae47d67f95fc23fe28a0bde15a120f25257e291"},
+    {file = "Pillow-8.2.0.tar.gz", hash = "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1"},
 ]
 pluggy = [
-    { file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d" },
-    { file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0" },
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 pockets = [
-    { file = "pockets-0.9.1-py2.py3-none-any.whl", hash = "sha256:68597934193c08a08eb2bf6a1d85593f627c22f9b065cc727a4f03f669d96d86" },
-    { file = "pockets-0.9.1.tar.gz", hash = "sha256:9320f1a3c6f7a9133fe3b571f283bcf3353cd70249025ae8d618e40e9f7e92b3" },
+    {file = "pockets-0.9.1-py2.py3-none-any.whl", hash = "sha256:68597934193c08a08eb2bf6a1d85593f627c22f9b065cc727a4f03f669d96d86"},
+    {file = "pockets-0.9.1.tar.gz", hash = "sha256:9320f1a3c6f7a9133fe3b571f283bcf3353cd70249025ae8d618e40e9f7e92b3"},
+]
+prometheus-client = [
+    {file = "prometheus_client-0.11.0-py2.py3-none-any.whl", hash = "sha256:b014bc76815eb1399da8ce5fc84b7717a3e63652b0c0f8804092c9363acab1b2"},
+    {file = "prometheus_client-0.11.0.tar.gz", hash = "sha256:3a8baade6cb80bcfe43297e33e7623f3118d660d41387593758e2fb1ea173a86"},
 ]
 psutil = [
-    { file = "psutil-5.7.3-cp27-none-win32.whl", hash = "sha256:1cd6a0c9fb35ece2ccf2d1dd733c1e165b342604c67454fd56a4c12e0a106787" },
-    { file = "psutil-5.7.3-cp27-none-win_amd64.whl", hash = "sha256:e02c31b2990dcd2431f4524b93491941df39f99619b0d312dfe1d4d530b08b4b" },
-    { file = "psutil-5.7.3-cp35-cp35m-win32.whl", hash = "sha256:56c85120fa173a5d2ad1d15a0c6e0ae62b388bfb956bb036ac231fbdaf9e4c22" },
-    { file = "psutil-5.7.3-cp35-cp35m-win_amd64.whl", hash = "sha256:fa38ac15dbf161ab1e941ff4ce39abd64b53fec5ddf60c23290daed2bc7d1157" },
-    { file = "psutil-5.7.3-cp36-cp36m-win32.whl", hash = "sha256:01bc82813fbc3ea304914581954979e637bcc7084e59ac904d870d6eb8bb2bc7" },
-    { file = "psutil-5.7.3-cp36-cp36m-win_amd64.whl", hash = "sha256:6a3e1fd2800ca45083d976b5478a2402dd62afdfb719b30ca46cd28bb25a2eb4" },
-    { file = "psutil-5.7.3-cp37-cp37m-win32.whl", hash = "sha256:fbcac492cb082fa38d88587d75feb90785d05d7e12d4565cbf1ecc727aff71b7" },
-    { file = "psutil-5.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:5d9106ff5ec2712e2f659ebbd112967f44e7d33f40ba40530c485cc5904360b8" },
-    { file = "psutil-5.7.3-cp38-cp38-win32.whl", hash = "sha256:ade6af32eb80a536eff162d799e31b7ef92ddcda707c27bbd077238065018df4" },
+    {file = "psutil-5.7.3-cp27-none-win32.whl", hash = "sha256:1cd6a0c9fb35ece2ccf2d1dd733c1e165b342604c67454fd56a4c12e0a106787"},
+    {file = "psutil-5.7.3-cp27-none-win_amd64.whl", hash = "sha256:e02c31b2990dcd2431f4524b93491941df39f99619b0d312dfe1d4d530b08b4b"},
+    {file = "psutil-5.7.3-cp35-cp35m-win32.whl", hash = "sha256:56c85120fa173a5d2ad1d15a0c6e0ae62b388bfb956bb036ac231fbdaf9e4c22"},
+    {file = "psutil-5.7.3-cp35-cp35m-win_amd64.whl", hash = "sha256:fa38ac15dbf161ab1e941ff4ce39abd64b53fec5ddf60c23290daed2bc7d1157"},
+    {file = "psutil-5.7.3-cp36-cp36m-win32.whl", hash = "sha256:01bc82813fbc3ea304914581954979e637bcc7084e59ac904d870d6eb8bb2bc7"},
+    {file = "psutil-5.7.3-cp36-cp36m-win_amd64.whl", hash = "sha256:6a3e1fd2800ca45083d976b5478a2402dd62afdfb719b30ca46cd28bb25a2eb4"},
+    {file = "psutil-5.7.3-cp37-cp37m-win32.whl", hash = "sha256:fbcac492cb082fa38d88587d75feb90785d05d7e12d4565cbf1ecc727aff71b7"},
+    {file = "psutil-5.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:5d9106ff5ec2712e2f659ebbd112967f44e7d33f40ba40530c485cc5904360b8"},
+    {file = "psutil-5.7.3-cp38-cp38-win32.whl", hash = "sha256:ade6af32eb80a536eff162d799e31b7ef92ddcda707c27bbd077238065018df4"},
     {file = "psutil-5.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:2cb55ef9591b03ef0104bedf67cc4edb38a3edf015cf8cf24007b99cb8497542"},
     {file = "psutil-5.7.3.tar.gz", hash = "sha256:af73f7bcebdc538eda9cc81d19db1db7bf26f103f91081d780bbacfcb620dee2"},
 ]
@@ -985,30 +1000,30 @@ pyasn1 = [
     {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
     {file = "pyasn1-0.4.8-py2.6.egg", hash = "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00"},
     {file = "pyasn1-0.4.8-py2.7.egg", hash = "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8"},
-    { file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d" },
-    { file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86" },
-    { file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7" },
-    { file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576" },
-    { file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12" },
-    { file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2" },
-    { file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359" },
-    { file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776" },
-    { file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba" },
+    {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
+    {file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"},
+    {file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7"},
+    {file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576"},
+    {file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12"},
+    {file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2"},
+    {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
+    {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
+    {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
 ]
 pygments = [
-    { file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e" },
-    { file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f" },
+    {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
+    {file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f"},
 ]
 pyparsing = [
-    { file = "pyparsing-3.0.0a2-py3-none-any.whl", hash = "sha256:1060635ca5ac864c2b7bc7b05a448df4e32d7d8c65e33cbe1514810d339672a2" },
-    { file = "pyparsing-3.0.0a2.tar.gz", hash = "sha256:56a551039101858c9e189ac9e66e330a03fb7079e97ba6b50193643905f450ce" },
+    {file = "pyparsing-3.0.0a2-py3-none-any.whl", hash = "sha256:1060635ca5ac864c2b7bc7b05a448df4e32d7d8c65e33cbe1514810d339672a2"},
+    {file = "pyparsing-3.0.0a2.tar.gz", hash = "sha256:56a551039101858c9e189ac9e66e330a03fb7079e97ba6b50193643905f450ce"},
 ]
 pyrate-limiter = [
-    { file = "pyrate-limiter-2.3.4.tar.gz", hash = "sha256:9fee2a529043ce242303a578c1b406e76f83b83286a966ea723d4864f05748b4" },
+    {file = "pyrate-limiter-2.3.4.tar.gz", hash = "sha256:9fee2a529043ce242303a578c1b406e76f83b83286a966ea723d4864f05748b4"},
 ]
 pyrogram = [
-    { file = "Pyrogram-1.0.7-py3-none-any.whl", hash = "sha256:bc8a5bd7fdbd56271b43561f5ea01cf7a983074d1ab799dabeb531fe279dcc6f" },
-    { file = "Pyrogram-1.0.7.tar.gz", hash = "sha256:95beff6eb1dbee38a96405a0d6600fda5ccbc8a9f29e693543f45b3a2ef0245b" },
+    {file = "Pyrogram-1.0.7-py3-none-any.whl", hash = "sha256:bc8a5bd7fdbd56271b43561f5ea01cf7a983074d1ab799dabeb531fe279dcc6f"},
+    {file = "Pyrogram-1.0.7.tar.gz", hash = "sha256:95beff6eb1dbee38a96405a0d6600fda5ccbc8a9f29e693543f45b3a2ef0245b"},
 ]
 pysocks = [
     {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},
@@ -1024,23 +1039,23 @@ pytest-asyncio = [
     {file = "pytest_asyncio-0.14.0-py3-none-any.whl", hash = "sha256:2eae1e34f6c68fc0a9dc12d4bea190483843ff4708d24277c41568d6b6044f1d"},
 ]
 python-dateutil = [
-    { file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c" },
-    { file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a" },
+    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
+    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
 ]
 pytz = [
-    { file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798" },
-    { file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da" },
+    {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
+    {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
 ]
 pywin32 = [
-    { file = "pywin32-227-cp27-cp27m-win32.whl", hash = "sha256:371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0" },
-    { file = "pywin32-227-cp27-cp27m-win_amd64.whl", hash = "sha256:4cdad3e84191194ea6d0dd1b1b9bdda574ff563177d2adf2b4efec2a244fa116" },
-    { file = "pywin32-227-cp35-cp35m-win32.whl", hash = "sha256:f4c5be1a293bae0076d93c88f37ee8da68136744588bc5e2be2f299a34ceb7aa" },
-    { file = "pywin32-227-cp35-cp35m-win_amd64.whl", hash = "sha256:a929a4af626e530383a579431b70e512e736e9588106715215bf685a3ea508d4" },
-    { file = "pywin32-227-cp36-cp36m-win32.whl", hash = "sha256:300a2db938e98c3e7e2093e4491439e62287d0d493fe07cce110db070b54c0be" },
-    { file = "pywin32-227-cp36-cp36m-win_amd64.whl", hash = "sha256:9b31e009564fb95db160f154e2aa195ed66bcc4c058ed72850d047141b36f3a2" },
-    { file = "pywin32-227-cp37-cp37m-win32.whl", hash = "sha256:47a3c7551376a865dd8d095a98deba954a98f326c6fe3c72d8726ca6e6b15507" },
-    { file = "pywin32-227-cp37-cp37m-win_amd64.whl", hash = "sha256:31f88a89139cb2adc40f8f0e65ee56a8c585f629974f9e07622ba80199057511" },
-    { file = "pywin32-227-cp38-cp38-win32.whl", hash = "sha256:7f18199fbf29ca99dff10e1f09451582ae9e372a892ff03a28528a24d55875bc" },
+    {file = "pywin32-227-cp27-cp27m-win32.whl", hash = "sha256:371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0"},
+    {file = "pywin32-227-cp27-cp27m-win_amd64.whl", hash = "sha256:4cdad3e84191194ea6d0dd1b1b9bdda574ff563177d2adf2b4efec2a244fa116"},
+    {file = "pywin32-227-cp35-cp35m-win32.whl", hash = "sha256:f4c5be1a293bae0076d93c88f37ee8da68136744588bc5e2be2f299a34ceb7aa"},
+    {file = "pywin32-227-cp35-cp35m-win_amd64.whl", hash = "sha256:a929a4af626e530383a579431b70e512e736e9588106715215bf685a3ea508d4"},
+    {file = "pywin32-227-cp36-cp36m-win32.whl", hash = "sha256:300a2db938e98c3e7e2093e4491439e62287d0d493fe07cce110db070b54c0be"},
+    {file = "pywin32-227-cp36-cp36m-win_amd64.whl", hash = "sha256:9b31e009564fb95db160f154e2aa195ed66bcc4c058ed72850d047141b36f3a2"},
+    {file = "pywin32-227-cp37-cp37m-win32.whl", hash = "sha256:47a3c7551376a865dd8d095a98deba954a98f326c6fe3c72d8726ca6e6b15507"},
+    {file = "pywin32-227-cp37-cp37m-win_amd64.whl", hash = "sha256:31f88a89139cb2adc40f8f0e65ee56a8c585f629974f9e07622ba80199057511"},
+    {file = "pywin32-227-cp38-cp38-win32.whl", hash = "sha256:7f18199fbf29ca99dff10e1f09451582ae9e372a892ff03a28528a24d55875bc"},
     {file = "pywin32-227-cp38-cp38-win_amd64.whl", hash = "sha256:7c1ae32c489dc012930787f06244426f8356e129184a02c25aef163917ce158e"},
     {file = "pywin32-227-cp39-cp39-win32.whl", hash = "sha256:c054c52ba46e7eb6b7d7dfae4dbd987a1bb48ee86debe3f245a2884ece46e295"},
     {file = "pywin32-227-cp39-cp39-win_amd64.whl", hash = "sha256:f27cec5e7f588c3d1051651830ecc00294f90728d19c3bf6916e6dba93ea357c"},
@@ -1058,70 +1073,70 @@ requests-mock = [
     {file = "requests_mock-1.8.0-py2.py3-none-any.whl", hash = "sha256:11215c6f4df72702aa357f205cf1e537cffd7392b3e787b58239bde5fb3db53b"},
 ]
 rsa = [
-    { file = "rsa-4.7.2-py3-none-any.whl", hash = "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2" },
-    { file = "rsa-4.7.2.tar.gz", hash = "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9" },
+    {file = "rsa-4.7.2-py3-none-any.whl", hash = "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2"},
+    {file = "rsa-4.7.2.tar.gz", hash = "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"},
 ]
 simple-heartbeat = [
-    { file = "simple-heartbeat-0.1.2.tar.gz", hash = "sha256:c9860bca61e730b73b449a18580a02a19ac3577e5cf59fcbb9699884e4ff18d2" },
+    {file = "simple-heartbeat-0.1.2.tar.gz", hash = "sha256:c9860bca61e730b73b449a18580a02a19ac3577e5cf59fcbb9699884e4ff18d2"},
 ]
 six = [
-    { file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced" },
-    { file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259" },
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
 snowballstemmer = [
-    { file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2" },
-    { file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914" },
+    {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},
+    {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
 ]
 sphinx = [
-    { file = "Sphinx-4.0.2-py3-none-any.whl", hash = "sha256:d1cb10bee9c4231f1700ec2e24a91be3f3a3aba066ea4ca9f3bbe47e59d5a1d4" },
-    { file = "Sphinx-4.0.2.tar.gz", hash = "sha256:b5c2ae4120bf00c799ba9b3699bc895816d272d120080fbc967292f29b52b48c" },
+    {file = "Sphinx-4.0.2-py3-none-any.whl", hash = "sha256:d1cb10bee9c4231f1700ec2e24a91be3f3a3aba066ea4ca9f3bbe47e59d5a1d4"},
+    {file = "Sphinx-4.0.2.tar.gz", hash = "sha256:b5c2ae4120bf00c799ba9b3699bc895816d272d120080fbc967292f29b52b48c"},
 ]
 sphinx-rtd-theme = [
-    { file = "sphinx_rtd_theme-0.5.2-py2.py3-none-any.whl", hash = "sha256:4a05bdbe8b1446d77a01e20a23ebc6777c74f43237035e76be89699308987d6f" },
-    { file = "sphinx_rtd_theme-0.5.2.tar.gz", hash = "sha256:32bd3b5d13dc8186d7a42fc816a23d32e83a4827d7d9882948e7b837c232da5a" },
+    {file = "sphinx_rtd_theme-0.5.2-py2.py3-none-any.whl", hash = "sha256:4a05bdbe8b1446d77a01e20a23ebc6777c74f43237035e76be89699308987d6f"},
+    {file = "sphinx_rtd_theme-0.5.2.tar.gz", hash = "sha256:32bd3b5d13dc8186d7a42fc816a23d32e83a4827d7d9882948e7b837c232da5a"},
 ]
 sphinxcontrib-applehelp = [
-    { file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58" },
-    { file = "sphinxcontrib_applehelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a" },
+    {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
+    {file = "sphinxcontrib_applehelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a"},
 ]
 sphinxcontrib-devhelp = [
-    { file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4" },
-    { file = "sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e" },
+    {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
+    {file = "sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e"},
 ]
 sphinxcontrib-htmlhelp = [
-    { file = "sphinxcontrib-htmlhelp-2.0.0.tar.gz", hash = "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2" },
-    { file = "sphinxcontrib_htmlhelp-2.0.0-py2.py3-none-any.whl", hash = "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07" },
+    {file = "sphinxcontrib-htmlhelp-2.0.0.tar.gz", hash = "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"},
+    {file = "sphinxcontrib_htmlhelp-2.0.0-py2.py3-none-any.whl", hash = "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07"},
 ]
 sphinxcontrib-jsmath = [
-    { file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8" },
-    { file = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178" },
+    {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
+    {file = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"},
 ]
 sphinxcontrib-napoleon = [
-    { file = "sphinxcontrib-napoleon-0.7.tar.gz", hash = "sha256:407382beed396e9f2d7f3043fad6afda95719204a1e1a231ac865f40abcbfcf8" },
-    { file = "sphinxcontrib_napoleon-0.7-py2.py3-none-any.whl", hash = "sha256:711e41a3974bdf110a484aec4c1a556799eb0b3f3b897521a018ad7e2db13fef" },
+    {file = "sphinxcontrib-napoleon-0.7.tar.gz", hash = "sha256:407382beed396e9f2d7f3043fad6afda95719204a1e1a231ac865f40abcbfcf8"},
+    {file = "sphinxcontrib_napoleon-0.7-py2.py3-none-any.whl", hash = "sha256:711e41a3974bdf110a484aec4c1a556799eb0b3f3b897521a018ad7e2db13fef"},
 ]
 sphinxcontrib-qthelp = [
-    { file = "sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72" },
-    { file = "sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6" },
+    {file = "sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"},
+    {file = "sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"},
 ]
 sphinxcontrib-serializinghtml = [
-    { file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952" },
-    { file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd" },
+    {file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"},
+    {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
 ]
 sphinxcontrib-websupport = [
-    { file = "sphinxcontrib-websupport-1.2.4.tar.gz", hash = "sha256:4edf0223a0685a7c485ae5a156b6f529ba1ee481a1417817935b20bde1956232" },
-    { file = "sphinxcontrib_websupport-1.2.4-py2.py3-none-any.whl", hash = "sha256:6fc9287dfc823fe9aa432463edd6cea47fa9ebbf488d7f289b322ffcfca075c7" },
+    {file = "sphinxcontrib-websupport-1.2.4.tar.gz", hash = "sha256:4edf0223a0685a7c485ae5a156b6f529ba1ee481a1417817935b20bde1956232"},
+    {file = "sphinxcontrib_websupport-1.2.4-py2.py3-none-any.whl", hash = "sha256:6fc9287dfc823fe9aa432463edd6cea47fa9ebbf488d7f289b322ffcfca075c7"},
 ]
 taskipy = [
-    { file = "taskipy-1.4.0-py3-none-any.whl", hash = "sha256:2caa3d4897aee1e17eddabf7b92b3a8d8824eb17d3932b69381b8306883c106a" },
-    { file = "taskipy-1.4.0.tar.gz", hash = "sha256:9fa86f9d7b5816d7ef789bc1631ee3bf78290554e251dc2dc29cb9ddbf9ebe1e" },
+    {file = "taskipy-1.4.0-py3-none-any.whl", hash = "sha256:2caa3d4897aee1e17eddabf7b92b3a8d8824eb17d3932b69381b8306883c106a"},
+    {file = "taskipy-1.4.0.tar.gz", hash = "sha256:9fa86f9d7b5816d7ef789bc1631ee3bf78290554e251dc2dc29cb9ddbf9ebe1e"},
 ]
 telethon = [
-    { file = "Telethon-1.21.1-py3-none-any.whl", hash = "sha256:df643fc988708ad16d16de834ffa12ad4bfa3f956473d835c8158e2283b885ea" },
-    { file = "Telethon-1.21.1.tar.gz", hash = "sha256:993c837ef745addf972a27d7bfba0ce518a2863d1a50e0737255b764d23e0ef2" },
+    {file = "Telethon-1.21.1-py3-none-any.whl", hash = "sha256:df643fc988708ad16d16de834ffa12ad4bfa3f956473d835c8158e2283b885ea"},
+    {file = "Telethon-1.21.1.tar.gz", hash = "sha256:993c837ef745addf972a27d7bfba0ce518a2863d1a50e0737255b764d23e0ef2"},
 ]
 tgintegration = [
-    { file = "tgintegration-1.1.0-py3-none-any.whl", hash = "sha256:e414af8cdede8b10bbc51410083d48883bee8c319044f8c5612ed39c97ab9cfc" },
+    {file = "tgintegration-1.1.0-py3-none-any.whl", hash = "sha256:e414af8cdede8b10bbc51410083d48883bee8c319044f8c5612ed39c97ab9cfc"},
     {file = "tgintegration-1.1.0.tar.gz", hash = "sha256:3f6df83e4ac636d2472ebebd86a25159b754ffe40621b63a8faf368f7530f8de"},
 ]
 toml = [
@@ -1138,57 +1153,57 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 urllib3 = [
-    { file = "urllib3-1.25.11-py2.py3-none-any.whl", hash = "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e" },
-    { file = "urllib3-1.25.11.tar.gz", hash = "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2" },
+    {file = "urllib3-1.25.11-py2.py3-none-any.whl", hash = "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"},
+    {file = "urllib3-1.25.11.tar.gz", hash = "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2"},
 ]
 wcwidth = [
-    { file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784" },
-    { file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83" },
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
 websocket-client = [
-    { file = "websocket_client-0.57.0-py2.py3-none-any.whl", hash = "sha256:0fc45c961324d79c781bab301359d5a1b00b13ad1b10415a4780229ef71a5549" },
-    { file = "websocket_client-0.57.0.tar.gz", hash = "sha256:d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010" },
+    {file = "websocket_client-0.57.0-py2.py3-none-any.whl", hash = "sha256:0fc45c961324d79c781bab301359d5a1b00b13ad1b10415a4780229ef71a5549"},
+    {file = "websocket_client-0.57.0.tar.gz", hash = "sha256:d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010"},
 ]
 yarl = [
-    { file = "yarl-1.6.3-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:0355a701b3998dcd832d0dc47cc5dedf3874f966ac7f870e0f3a6788d802d434" },
-    { file = "yarl-1.6.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:bafb450deef6861815ed579c7a6113a879a6ef58aed4c3a4be54400ae8871478" },
-    { file = "yarl-1.6.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:547f7665ad50fa8563150ed079f8e805e63dd85def6674c97efd78eed6c224a6" },
-    { file = "yarl-1.6.3-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:63f90b20ca654b3ecc7a8d62c03ffa46999595f0167d6450fa8383bab252987e" },
-    { file = "yarl-1.6.3-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:97b5bdc450d63c3ba30a127d018b866ea94e65655efaf889ebeabc20f7d12406" },
-    { file = "yarl-1.6.3-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:d8d07d102f17b68966e2de0e07bfd6e139c7c02ef06d3a0f8d2f0f055e13bb76" },
-    { file = "yarl-1.6.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:15263c3b0b47968c1d90daa89f21fcc889bb4b1aac5555580d74565de6836366" },
-    { file = "yarl-1.6.3-cp36-cp36m-win32.whl", hash = "sha256:b5dfc9a40c198334f4f3f55880ecf910adebdcb2a0b9a9c23c9345faa9185721" },
-    { file = "yarl-1.6.3-cp36-cp36m-win_amd64.whl", hash = "sha256:b2e9a456c121e26d13c29251f8267541bd75e6a1ccf9e859179701c36a078643" },
-    { file = "yarl-1.6.3-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:ce3beb46a72d9f2190f9e1027886bfc513702d748047b548b05dab7dfb584d2e" },
-    { file = "yarl-1.6.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2ce4c621d21326a4a5500c25031e102af589edb50c09b321049e388b3934eec3" },
-    { file = "yarl-1.6.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:d26608cf178efb8faa5ff0f2d2e77c208f471c5a3709e577a7b3fd0445703ac8" },
-    { file = "yarl-1.6.3-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:4c5bcfc3ed226bf6419f7a33982fb4b8ec2e45785a0561eb99274ebbf09fdd6a" },
-    { file = "yarl-1.6.3-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:4736eaee5626db8d9cda9eb5282028cc834e2aeb194e0d8b50217d707e98bb5c" },
-    { file = "yarl-1.6.3-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:68dc568889b1c13f1e4745c96b931cc94fdd0defe92a72c2b8ce01091b22e35f" },
-    { file = "yarl-1.6.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:7356644cbed76119d0b6bd32ffba704d30d747e0c217109d7979a7bc36c4d970" },
-    { file = "yarl-1.6.3-cp37-cp37m-win32.whl", hash = "sha256:00d7ad91b6583602eb9c1d085a2cf281ada267e9a197e8b7cae487dadbfa293e" },
-    { file = "yarl-1.6.3-cp37-cp37m-win_amd64.whl", hash = "sha256:69ee97c71fee1f63d04c945f56d5d726483c4762845400a6795a3b75d56b6c50" },
-    { file = "yarl-1.6.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:e46fba844f4895b36f4c398c5af062a9808d1f26b2999c58909517384d5deda2" },
-    { file = "yarl-1.6.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:31ede6e8c4329fb81c86706ba8f6bf661a924b53ba191b27aa5fcee5714d18ec" },
-    { file = "yarl-1.6.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fcbb48a93e8699eae920f8d92f7160c03567b421bc17362a9ffbbd706a816f71" },
-    { file = "yarl-1.6.3-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:72a660bdd24497e3e84f5519e57a9ee9220b6f3ac4d45056961bf22838ce20cc" },
-    { file = "yarl-1.6.3-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:324ba3d3c6fee56e2e0b0d09bf5c73824b9f08234339d2b788af65e60040c959" },
-    { file = "yarl-1.6.3-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:e6b5460dc5ad42ad2b36cca524491dfcaffbfd9c8df50508bddc354e787b8dc2" },
-    { file = "yarl-1.6.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:6d6283d8e0631b617edf0fd726353cb76630b83a089a40933043894e7f6721e2" },
-    { file = "yarl-1.6.3-cp38-cp38-win32.whl", hash = "sha256:9ede61b0854e267fd565e7527e2f2eb3ef8858b301319be0604177690e1a3896" },
-    { file = "yarl-1.6.3-cp38-cp38-win_amd64.whl", hash = "sha256:f0b059678fd549c66b89bed03efcabb009075bd131c248ecdf087bdb6faba24a" },
-    { file = "yarl-1.6.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:329412812ecfc94a57cd37c9d547579510a9e83c516bc069470db5f75684629e" },
-    { file = "yarl-1.6.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c49ff66d479d38ab863c50f7bb27dee97c6627c5fe60697de15529da9c3de724" },
-    { file = "yarl-1.6.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f040bcc6725c821a4c0665f3aa96a4d0805a7aaf2caf266d256b8ed71b9f041c" },
-    { file = "yarl-1.6.3-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:d5c32c82990e4ac4d8150fd7652b972216b204de4e83a122546dce571c1bdf25" },
-    { file = "yarl-1.6.3-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:d597767fcd2c3dc49d6eea360c458b65643d1e4dbed91361cf5e36e53c1f8c96" },
-    { file = "yarl-1.6.3-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:8aa3decd5e0e852dc68335abf5478a518b41bf2ab2f330fe44916399efedfae0" },
-    { file = "yarl-1.6.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:73494d5b71099ae8cb8754f1df131c11d433b387efab7b51849e7e1e851f07a4" },
-    { file = "yarl-1.6.3-cp39-cp39-win32.whl", hash = "sha256:5b883e458058f8d6099e4420f0cc2567989032b5f34b271c0827de9f1079a424" },
-    { file = "yarl-1.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:4953fb0b4fdb7e08b2f3b3be80a00d28c5c8a2056bb066169de00e6501b986b6" },
-    { file = "yarl-1.6.3.tar.gz", hash = "sha256:8a9066529240171b68893d60dca86a763eae2139dd42f42106b03cf4b426bf10" },
+    {file = "yarl-1.6.3-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:0355a701b3998dcd832d0dc47cc5dedf3874f966ac7f870e0f3a6788d802d434"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:bafb450deef6861815ed579c7a6113a879a6ef58aed4c3a4be54400ae8871478"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:547f7665ad50fa8563150ed079f8e805e63dd85def6674c97efd78eed6c224a6"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:63f90b20ca654b3ecc7a8d62c03ffa46999595f0167d6450fa8383bab252987e"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:97b5bdc450d63c3ba30a127d018b866ea94e65655efaf889ebeabc20f7d12406"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:d8d07d102f17b68966e2de0e07bfd6e139c7c02ef06d3a0f8d2f0f055e13bb76"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:15263c3b0b47968c1d90daa89f21fcc889bb4b1aac5555580d74565de6836366"},
+    {file = "yarl-1.6.3-cp36-cp36m-win32.whl", hash = "sha256:b5dfc9a40c198334f4f3f55880ecf910adebdcb2a0b9a9c23c9345faa9185721"},
+    {file = "yarl-1.6.3-cp36-cp36m-win_amd64.whl", hash = "sha256:b2e9a456c121e26d13c29251f8267541bd75e6a1ccf9e859179701c36a078643"},
+    {file = "yarl-1.6.3-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:ce3beb46a72d9f2190f9e1027886bfc513702d748047b548b05dab7dfb584d2e"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2ce4c621d21326a4a5500c25031e102af589edb50c09b321049e388b3934eec3"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:d26608cf178efb8faa5ff0f2d2e77c208f471c5a3709e577a7b3fd0445703ac8"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:4c5bcfc3ed226bf6419f7a33982fb4b8ec2e45785a0561eb99274ebbf09fdd6a"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:4736eaee5626db8d9cda9eb5282028cc834e2aeb194e0d8b50217d707e98bb5c"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:68dc568889b1c13f1e4745c96b931cc94fdd0defe92a72c2b8ce01091b22e35f"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:7356644cbed76119d0b6bd32ffba704d30d747e0c217109d7979a7bc36c4d970"},
+    {file = "yarl-1.6.3-cp37-cp37m-win32.whl", hash = "sha256:00d7ad91b6583602eb9c1d085a2cf281ada267e9a197e8b7cae487dadbfa293e"},
+    {file = "yarl-1.6.3-cp37-cp37m-win_amd64.whl", hash = "sha256:69ee97c71fee1f63d04c945f56d5d726483c4762845400a6795a3b75d56b6c50"},
+    {file = "yarl-1.6.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:e46fba844f4895b36f4c398c5af062a9808d1f26b2999c58909517384d5deda2"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:31ede6e8c4329fb81c86706ba8f6bf661a924b53ba191b27aa5fcee5714d18ec"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fcbb48a93e8699eae920f8d92f7160c03567b421bc17362a9ffbbd706a816f71"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:72a660bdd24497e3e84f5519e57a9ee9220b6f3ac4d45056961bf22838ce20cc"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:324ba3d3c6fee56e2e0b0d09bf5c73824b9f08234339d2b788af65e60040c959"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:e6b5460dc5ad42ad2b36cca524491dfcaffbfd9c8df50508bddc354e787b8dc2"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:6d6283d8e0631b617edf0fd726353cb76630b83a089a40933043894e7f6721e2"},
+    {file = "yarl-1.6.3-cp38-cp38-win32.whl", hash = "sha256:9ede61b0854e267fd565e7527e2f2eb3ef8858b301319be0604177690e1a3896"},
+    {file = "yarl-1.6.3-cp38-cp38-win_amd64.whl", hash = "sha256:f0b059678fd549c66b89bed03efcabb009075bd131c248ecdf087bdb6faba24a"},
+    {file = "yarl-1.6.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:329412812ecfc94a57cd37c9d547579510a9e83c516bc069470db5f75684629e"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c49ff66d479d38ab863c50f7bb27dee97c6627c5fe60697de15529da9c3de724"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f040bcc6725c821a4c0665f3aa96a4d0805a7aaf2caf266d256b8ed71b9f041c"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:d5c32c82990e4ac4d8150fd7652b972216b204de4e83a122546dce571c1bdf25"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:d597767fcd2c3dc49d6eea360c458b65643d1e4dbed91361cf5e36e53c1f8c96"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:8aa3decd5e0e852dc68335abf5478a518b41bf2ab2f330fe44916399efedfae0"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:73494d5b71099ae8cb8754f1df131c11d433b387efab7b51849e7e1e851f07a4"},
+    {file = "yarl-1.6.3-cp39-cp39-win32.whl", hash = "sha256:5b883e458058f8d6099e4420f0cc2567989032b5f34b271c0827de9f1079a424"},
+    {file = "yarl-1.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:4953fb0b4fdb7e08b2f3b3be80a00d28c5c8a2056bb066169de00e6501b986b6"},
+    {file = "yarl-1.6.3.tar.gz", hash = "sha256:8a9066529240171b68893d60dca86a763eae2139dd42f42106b03cf4b426bf10"},
 ]
 yippi = [
-    { file = "yippi-0.2.0.1-py3-none-any.whl", hash = "sha256:92947d1224ae8b008567e95e0749334ebd6029fd58dd1cf91cfb5c5856782a88" },
-    { file = "yippi-0.2.0.1.tar.gz", hash = "sha256:c82cf67f3cce5146c5ac6b292e6ffac11d502230ea68fb513f847502150c6615" },
+    {file = "yippi-0.2.0.1-py3-none-any.whl", hash = "sha256:92947d1224ae8b008567e95e0749334ebd6029fd58dd1cf91cfb5c5856782a88"},
+    {file = "yippi-0.2.0.1.tar.gz", hash = "sha256:c82cf67f3cce5146c5ac6b292e6ffac11d502230ea68fb513f847502150c6615"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ tomlkit = "^0.7.0"
 Telethon = "^1.21.1"
 Pillow = "^8.2.0"
 yippi = "0.2.0.1"
+prometheus-client = "^0.11.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.1"

--- a/run.py
+++ b/run.py
@@ -22,13 +22,6 @@ def setup_logging() -> None:
     file_handler.setFormatter(formatter)
     fa_logger.addHandler(file_handler)
 
-    # Set up feature usage logger. Anonymous information on how often features are used
-    usage_logger = logging.getLogger("usage")
-    usage_logger.setLevel(logging.DEBUG)
-    usage_file = logging.FileHandler("logs/usage.log")
-    usage_file.setFormatter(formatter)
-    usage_logger.addHandler(usage_file)
-
 
 if __name__ == "__main__":
     setup_logging()


### PR DESCRIPTION
This PR should add a whole bunch of prometheus metrics to the bot, which should be handy for checking status and error rates and helping focus attention where it is needed.

I've removed the usage_logger also, because the purpose of that was to find out which features are most used, and prometheus metrics are a much better way to do that.
I can also remove the simple-heartbeat calls, once this is set up and running, but I'll do that in  a later PR