### PR TITLE
Track real time lag of the subscription watcher

### DIFF
--- a/fa_search_bot/sites/fa_submission.py
+++ b/fa_search_bot/sites/fa_submission.py
@@ -132,6 +132,7 @@ class FASubmission(ABC):
             "Mature": Rating.MATURE,
             "General": Rating.GENERAL,
         }[full_dict["rating"]]
+        posted_at = dateutil.parser.parse(full_dict["posted_at"])
         new_submission = FASubmissionFull(
             submission_id,
             thumbnail_url,
@@ -142,6 +143,7 @@ class FASubmission(ABC):
             description,
             keywords,
             rating,
+            posted_at,
         )
         return new_submission
 
@@ -226,6 +228,7 @@ class FASubmissionFull(FASubmissionShort):
         description: str,
         keywords: List[str],
         rating: Rating,
+        posted_at: datetime.datetime,
     ) -> None:
         super().__init__(submission_id, thumbnail_url, title, author)
         self.download_url = download_url
@@ -233,6 +236,7 @@ class FASubmissionFull(FASubmissionShort):
         self.description = description
         self.keywords = keywords
         self.rating = rating
+        self.posted_at = posted_at
         self._download_file_size: Optional[int] = None
 
     @property

--- a/fa_search_bot/subscription_watcher.py
+++ b/fa_search_bot/subscription_watcher.py
@@ -95,6 +95,10 @@ gauge_backlog = Gauge(
     "fasearchbot_fasubwatcher_backlog",
     "Length of the latest list of new submissions to check",
 )
+gauge_backlog_seconds = Gauge(
+    fasearchbot_fasubwatcher_backlog_seconds",
+    "Age, in seconds, of the latest checked submission",
+)
 
 
 class SubscriptionWatcher:
@@ -169,6 +173,8 @@ class SubscriptionWatcher:
                     subs_other_failed.inc()
                     subs_failed.inc()
                     continue
+                # Log the age of the latest checked submission
+                gauge_backlog_seconds.set((datetime.datetime.now(tz=datetime.timezone.utc) - full_result.posted_at).total_seconds())
                 # Copy subscriptions, to avoid "changed size during iteration" issues
                 subscriptions = self.subscriptions.copy()
                 # Check which subscriptions match


### PR DESCRIPTION
Rather than just tracking how many posts are in the queue to check, lets read the posting time from submissions, and track how far behind that we are in seconds, as a prometheus metric ofc