### PR TITLE
Try home page for latest result

### DIFF
--- a/fa_search_bot/sites/furaffinity/fa_export_api.py
+++ b/fa_search_bot/sites/furaffinity/fa_export_api.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import requests
 from prometheus_client import Counter, Enum, Gauge, Histogram
 
-from fa_search_bot.sites.furaffinity.fa_submission import FAStatus, FASubmission
+from fa_search_bot.sites.furaffinity.fa_submission import FAStatus, FASubmission, FAHomePage
 
 if TYPE_CHECKING:
     from typing import List, Optional
@@ -61,6 +61,7 @@ class Endpoint(enum.Enum):
     USER_FAVS = "user_favs"
     SEARCH = "search"
     BROWSE = "browse"
+    HOME = "home"
     STATUS = "status"
 
 
@@ -186,6 +187,15 @@ class FAExportAPI:
         if submissions:
             site_latest_id.set(submissions[0].submission_id)
         return submissions
+
+    async def get_home_page(self) -> FAHomePage:
+        logger.debug("Getting home page")
+        resp = await self._api_request_with_retry("home.json", Endpoint.HOME)
+        data = resp.json()
+        home_page = FAHomePage.from_dict(data)
+        latest_id = max(home_page.all_submissions(), key=lambda sub: int(sub.submission_id))
+        site_latest_id.set(latest_id)
+        return home_page
 
     def status(self) -> FAStatus:
         logger.debug("Getting status page")

--- a/fa_search_bot/sites/furaffinity/fa_export_api.py
+++ b/fa_search_bot/sites/furaffinity/fa_export_api.py
@@ -193,8 +193,10 @@ class FAExportAPI:
         resp = await self._api_request_with_retry("home.json", Endpoint.HOME)
         data = resp.json()
         home_page = FAHomePage.from_dict(data)
-        latest_id = max(home_page.all_submissions(), key=lambda sub: int(sub.submission_id))
-        site_latest_id.set(latest_id)
+        submissions = home_page.all_submissions()
+        if submissions:
+            latest_sub = max(submissions, key=lambda sub: int(sub.submission_id))
+            site_latest_id.set(latest_sub.submission_id)
         return home_page
 
     def status(self) -> FAStatus:

--- a/fa_search_bot/sites/furaffinity/fa_submission.py
+++ b/fa_search_bot/sites/furaffinity/fa_submission.py
@@ -4,7 +4,7 @@ import logging
 import re
 from abc import ABC
 from enum import Enum
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict, Dict
 
 import dateutil.parser
 import requests
@@ -274,4 +274,33 @@ class FAStatus:
             status_dict["online"]["other"],
             status_dict["online"]["total"],
             dateutil.parser.parse(status_dict["fa_server_time_at"]),
+        )
+
+
+class FAHomeCategory:
+    def __init__(self, name: str, submissions: List[FASubmissionShort]):
+        self.name = name
+        self.submissions = submissions
+
+
+class FAHomePage:
+    def __init__(self, categories: List[FAHomeCategory]):
+        self.categories = categories
+
+    def all_submissions(self) -> List[FASubmissionShort]:
+        all_subs = []
+        for category in self.categories:
+            all_subs.extend(category.submissions)
+        return all_subs
+
+    @classmethod
+    def from_dict(cls, home_dict: Dict[str, List[Dict]]) -> "FAHomePage":
+        return cls(
+            [
+                FAHomeCategory(
+                    key,
+                    [FASubmission.from_short_dict(sub) for sub in sub_list]
+                )
+                for key, sub_list in home_dict.items()
+            ]
         )


### PR DESCRIPTION
Currently, the browse page is locked down for access. We only need the latest ID from it anyway, so lets try fetching the home page if browse fails, and using that instead.